### PR TITLE
EAS-476 First pass at changing app refs from notify to eas

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ flask command purge_functional_test_data -u <functional tests user name prefix>
 
 On the server
 ```
-cf run-task notify-api "flask command purge_functional_test_data -u <functional tests user name prefix>"
+cf run-task eas-api "flask command purge_functional_test_data -u <functional tests user name prefix>"
 ```
 
 All commands and command options have a --help command if you need more information.

--- a/app/config.py
+++ b/app/config.py
@@ -439,7 +439,7 @@ class Development(Config):
     NOTIFY_LOG_PATH = "application.log"
     NOTIFY_EMAIL_DOMAIN = "notify.tools"
 
-    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/notification_api")
+    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/emergency_alerts_api")
     REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 
     ANTIVIRUS_ENABLED = os.getenv("ANTIVIRUS_ENABLED") == "1"
@@ -475,7 +475,7 @@ class Test(Development):
     LETTER_SANITISE_BUCKET_NAME = "test-letters-sanitise"
 
     # this is overriden in jenkins and on cloudfoundry
-    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/test_notification_api")
+    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://localhost/test_emergency_alerts_api")
     SQLALCHEMY_RECORD_QUERIES = False
 
     CELERY = {**Config.CELERY, "broker_url": "you-forgot-to-mock-celery-in-your-tests://"}

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -1,5 +1,5 @@
 {%- set app_vars = {
-  'notify-api': {
+  'eas-api': {
     'NOTIFY_APP_NAME': 'api',
     'disk_quota': '2G',
     'sqlalchemy_pool_size': 15,
@@ -7,9 +7,9 @@
       'STATSD_HOST': None
     },
     'routes': {
-      'preview': ['api.notify.works', 'notify-api-preview.apps.internal'],
-      'staging': ['api.staging-notify.works', 'notify-api-staging.apps.internal'],
-      'production': ['api.notifications.service.gov.uk', 'notify-api-production.apps.internal'],
+      'preview': ['api.notify.works', 'eas-api-preview.apps.internal'],
+      'staging': ['api.staging-notify.works', 'eas-api-staging.apps.internal'],
+      'production': ['api.notifications.service.gov.uk', 'eas-api-production.apps.internal'],
     },
     'health-check-type': 'port',
     'health-check-invocation-timeout': 3,
@@ -20,16 +20,16 @@
     },
   },
 
-  'notify-api-sms-receipts': {
+  'eas-api-sms-receipts': {
     'NOTIFY_APP_NAME': 'api',
     'disk_quota': '2G',
     'additional_env_vars': {
       'STATSD_HOST': None
     },
     'routes': {
-      'preview': ['api.notify.works/notifications/sms/mmg', 'api.notify.works/notifications/sms/firetext', 'notify-api-sms-receipts-preview.apps.internal'],
-      'staging': ['api.staging-notify.works/notifications/sms/mmg', 'api.staging-notify.works/notifications/sms/firetext', 'notify-api-sms-receipts-staging.apps.internal'],
-      'production': ['api.notifications.service.gov.uk/notifications/sms/mmg', 'api.notifications.service.gov.uk/notifications/sms/firetext', 'notify-api-sms-receipts-production.apps.internal' ],
+      'preview': ['api.notify.works/notifications/sms/mmg', 'api.notify.works/notifications/sms/firetext', 'eas-api-sms-receipts-preview.apps.internal'],
+      'staging': ['api.staging-notify.works/notifications/sms/mmg', 'api.staging-notify.works/notifications/sms/firetext', 'eas-api-sms-receipts-staging.apps.internal'],
+      'production': ['api.notifications.service.gov.uk/notifications/sms/mmg', 'api.notifications.service.gov.uk/notifications/sms/firetext', 'eas-api-sms-receipts-production.apps.internal' ],
     },
     'health-check-type': 'port',
     'health-check-invocation-timeout': 3,
@@ -40,7 +40,7 @@
     },
   },
 
-  'notify-api-db-migration': {
+  'eas-api-db-migration': {
     'NOTIFY_APP_NAME': 'api',
     'instances': {
       'preview': 0,
@@ -101,7 +101,7 @@ applications:
       - notify-db
       - notify-redis
       - logit-ssl-syslog-drain
-      {% if CF_APP == 'notify-api' %}
+      {% if CF_APP == 'eas-api' %}
       - notify-splunk
       {% endif %}
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -65,7 +65,7 @@ def run_migrations_online():
             context.run_migrations()
 
         # if we're running on the main db (as opposed to the test db)
-        if engine.url.database == "notification_api":
+        if engine.url.database == "emergency_alerts_api":
             with open(Path(__file__).parent / ".current-alembic-head", "w") as f:
                 # write the current head to `.current-alembic-head`. This will prevent conflicting migrations
                 # being merged at the same time and breaking the build.

--- a/paas-failwhale/README.md
+++ b/paas-failwhale/README.md
@@ -9,7 +9,7 @@ It returns a 503 error code and a standard json response for all routes.
 
 It should already be deployed, but if not (or if you need to make changes to the nginx config) you can deploy it by running
 
-    cf push notify-api-failwhale
+    cf push eas-api-failwhale
 
 To enable it you need to run
 

--- a/paas-failwhale/manifest.yml
+++ b/paas-failwhale/manifest.yml
@@ -1,7 +1,7 @@
 ---
 
 applications:
-  - name: notify-api-failwhale
+  - name: eas-api-failwhale
     buildpacks:
       - nginx_buildpack
     memory: 256M

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -8,7 +8,7 @@ source environment.sh
 # this script should be run from within your virtualenv so you can access the aws cli
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-"$(aws configure get aws_access_key_id)"}
 AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-"$(aws configure get aws_secret_access_key)"}
-SQLALCHEMY_DATABASE_URI="postgresql://postgres@host.docker.internal/notification_api"
+SQLALCHEMY_DATABASE_URI="postgresql://postgres@host.docker.internal/emergency_alerts_api"
 REDIS_URL="redis://host.docker.internal:6379"
 API_HOST_NAME="http://host.docker.internal:6011"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def create_test_db(database_uri):
         result = postgres_db.execute(sqlalchemy.sql.text("CREATE DATABASE {}".format(db_uri_parts[-1])))
         result.close()
     except sqlalchemy.exc.ProgrammingError:
-        # database "test_notification_api_master" already exists
+        # database "test_emergency_alerts_api_master" already exists
         pass
     finally:
         postgres_db.dispose()
@@ -70,7 +70,7 @@ def _notify_db(notify_api, worker_id):
     Manages the connection to the database. Generally this shouldn't be used, instead you should use the
     `notify_db_session` fixture which also cleans up any data you've got left over after your test run.
     """
-    assert "test_notification_api" in db.engine.url.database, "dont run tests against main db"
+    assert "test_emergency_alerts_api" in db.engine.url.database, "dont run tests against main db"
 
     # create a database for this worker thread -
     from flask import current_app


### PR DESCRIPTION
Before successfully building the Fujitsu "developer-tooling" Docker image from which we can run the containerised development environment, the app name and service references should be updated to reflect the change in ownership from "notifications" to "emergency alerts".

Where the long name/ref is used (notifications-admin), this becomes "emergency-alerts-admin".

The shortened form (notify-admin), as used to name the service instance for example, becomes "eas-admin" (eas -> emergency alerts system).

References to the db also change from notification_api to emergency_alerts_api.