### PR TITLE
EAS-476 Change references to utils package to emergency alerts package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ freeze-requirements: ## Pin all requirements including sub dependencies into req
 	pip-compile requirements.in
 
 .PHONY: bump-utils
-bump-utils:  # Bump notifications-utils package to latest version
-	${PYTHON_EXECUTABLE_PREFIX}python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"
+bump-utils:  # Bump emergency-alerts-utils package to latest version
+	${PYTHON_EXECUTABLE_PREFIX}python -c "from emergency_alerts_utils.version_tools import upgrade_version; upgrade_version()"
 
 .PHONY: clean
 clean:

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ notifications-python-client==6.3.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git@60.0.0-alpha
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ billiard==3.6.4.0
 blinker==1.5
     # via gds-metrics
 boto3==1.24.84
-    # via notifications-utils
+    # via emergency-alerts-utils
 botocore==1.27.84
     # via
     #   awscli
@@ -36,7 +36,7 @@ botocore==1.27.84
 cachetools==5.2.0
     # via
     #   -r requirements.in
-    #   notifications-utils
+    #   emergency-alerts-utils
 celery[sqs]==5.2.7
     # via -r requirements.in
 certifi==2022.12.7
@@ -84,7 +84,7 @@ flask==2.2.2
     #   flask-redis
     #   flask-sqlalchemy
     #   gds-metrics
-    #   notifications-utils
+    #   emergency-alerts-utils
 flask-bcrypt==1.0.1
     # via -r requirements.in
 flask-marshmallow==0.14.0
@@ -92,7 +92,7 @@ flask-marshmallow==0.14.0
 flask-migrate==3.1.0
     # via -r requirements.in
 flask-redis==0.4.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 flask-sqlalchemy==3.0.2
     # via
     #   -r requirements.in
@@ -102,9 +102,9 @@ fqdn==1.5.1
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
 geojson==2.5.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 govuk-bank-holidays==0.11
-    # via notifications-utils
+    # via emergency-alerts-utils
 greenlet==1.1.3
     # via eventlet
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
@@ -123,11 +123,11 @@ itsdangerous==2.1.2
     # via
     #   -r requirements.in
     #   flask
-    #   notifications-utils
+    #   emergency-alerts-utils
 jinja2==3.1.2
     # via
     #   flask
-    #   notifications-utils
+    #   emergency-alerts-utils
 jmespath==1.0.1
     # via
     #   boto3
@@ -155,20 +155,20 @@ marshmallow==3.18.0
 marshmallow-sqlalchemy==0.28.1
     # via -r requirements.in
 mistune==0.8.4
-    # via notifications-utils
+    # via emergency-alerts-utils
 notifications-python-client==6.3.0
     # via -r requirements.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
+emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git@60.0.0-alpha
     # via -r requirements.in
 orderedset==2.0.3
-    # via notifications-utils
+    # via emergency-alerts-utils
 packaging==21.3
     # via
     #   marshmallow
     #   marshmallow-sqlalchemy
     #   redis
 phonenumbers==8.12.56
-    # via notifications-utils
+    # via emergency-alerts-utils
 prometheus-client==0.14.1
     # via
     #   -r requirements.in
@@ -188,9 +188,9 @@ pyjwt==2.5.0
 pyparsing==3.0.9
     # via packaging
 pypdf2==2.11.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 pyproj==3.4.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
@@ -199,15 +199,15 @@ python-dateutil==2.8.2
     #   awscli-cwlogs
     #   botocore
 python-json-logger==2.0.4
-    # via notifications-utils
+    # via emergency-alerts-utils
 pytz==2022.4
     # via
     #   celery
-    #   notifications-utils
+    #   emergency-alerts-utils
 pyyaml==5.4.1
     # via
     #   awscli
-    #   notifications-utils
+    #   emergency-alerts-utils
 redis==4.3.4
     # via flask-redis
 requests==2.28.1
@@ -215,7 +215,7 @@ requests==2.28.1
     #   awscli-cwlogs
     #   govuk-bank-holidays
     #   notifications-python-client
-    #   notifications-utils
+    #   emergency-alerts-utils
 rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
@@ -227,7 +227,7 @@ s3transfer==0.6.0
     #   awscli
     #   boto3
 shapely==1.8.4
-    # via notifications-utils
+    # via emergency-alerts-utils
 six==1.16.0
     # via
     #   awscli-cwlogs
@@ -237,7 +237,7 @@ six==1.16.0
     #   python-dateutil
     #   rfc3339-validator
 smartypants==2.0.1
-    # via notifications-utils
+    # via emergency-alerts-utils
 soupsieve==2.3.2.post1
     # via beautifulsoup4
 sqlalchemy==1.4.41
@@ -247,7 +247,7 @@ sqlalchemy==1.4.41
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
 statsd==3.3.0
-    # via notifications-utils
+    # via emergency-alerts-utils
 typing-extensions==4.4.0
     # via pypdf2
 uri-template==1.2.0


### PR DESCRIPTION
- Import the new version of the emergency-alerts-utils package (version 60.0.0-alpha).
- Change package imports to refer to emergency_alerts_utils.