### PR TITLE
EAS-470 Add Flask config for decoupled docker deployment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -451,6 +451,12 @@ class Development(Config):
     CBC_PROXY_ENABLED = False
 
 
+class Decoupled(Development):
+    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://postgres:5432/emergency_alerts")
+    REDIS_URL = os.getenv("REDIS_URL", "redis://admin:6379/0")
+    API_HOST_NAME = os.getenv("API_HOST_NAME", "http://admin:6011")
+
+
 class Test(Development):
     NOTIFY_EMAIL_DOMAIN = "test.notify.com"
     FROM_NUMBER = "testing"
@@ -571,6 +577,7 @@ class Sandbox(CloudFoundryConfig):
 
 configs = {
     "development": Development,
+    "decoupled": Decoupled,
     "test": Test,
     "production": Production,
     "staging": Staging,

--- a/app/config.py
+++ b/app/config.py
@@ -452,6 +452,7 @@ class Development(Config):
 
 
 class Decoupled(Development):
+    NOTIFY_ENVIRONMENT = "decoupled"
     ADMIN_BASE_URL = "http://admin:6012"
     SQLALCHEMY_DATABASE_URI = "postgresql://pg/emergency_alerts"
     REDIS_URL = "redis://api:6379/0"

--- a/app/config.py
+++ b/app/config.py
@@ -453,8 +453,8 @@ class Development(Config):
 
 class Decoupled(Development):
     SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://postgres/emergency_alerts")
-    REDIS_URL = os.getenv("REDIS_URL", "redis://admin:6379/0")
-    API_HOST_NAME = os.getenv("API_HOST_NAME", "http://admin:6011")
+    REDIS_URL = os.getenv("REDIS_URL", "redis://api:6379/0")
+    API_HOST_NAME = os.getenv("API_HOST_NAME", "http://api:6011")
 
 
 class Test(Development):

--- a/app/config.py
+++ b/app/config.py
@@ -453,7 +453,7 @@ class Development(Config):
 
 class Decoupled(Development):
     ADMIN_BASE_URL = "http://admin:6012"
-    SQLALCHEMY_DATABASE_URI = "postgresql://postgres/emergency_alerts"
+    SQLALCHEMY_DATABASE_URI = "postgresql://pg/emergency_alerts"
     REDIS_URL = "redis://api:6379/0"
     API_HOST_NAME = "http://api:6011"
     TEMPLATE_PREVIEW_API_HOST = "http://api:6013"

--- a/app/config.py
+++ b/app/config.py
@@ -452,7 +452,7 @@ class Development(Config):
 
 
 class Decoupled(Development):
-    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://postgres:5432/emergency_alerts")
+    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://postgres/emergency_alerts")
     REDIS_URL = os.getenv("REDIS_URL", "redis://admin:6379/0")
     API_HOST_NAME = os.getenv("API_HOST_NAME", "http://admin:6011")
 

--- a/app/config.py
+++ b/app/config.py
@@ -452,9 +452,11 @@ class Development(Config):
 
 
 class Decoupled(Development):
-    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI", "postgresql://postgres/emergency_alerts")
-    REDIS_URL = os.getenv("REDIS_URL", "redis://api:6379/0")
-    API_HOST_NAME = os.getenv("API_HOST_NAME", "http://api:6011")
+    ADMIN_BASE_URL = "http://admin:6012"
+    SQLALCHEMY_DATABASE_URI = "postgresql://postgres/emergency_alerts"
+    REDIS_URL = "redis://api:6379/0"
+    API_HOST_NAME = "http://api:6011"
+    TEMPLATE_PREVIEW_API_HOST = "http://api:6013"
 
 
 class Test(Development):


### PR DESCRIPTION
To allow the admin, api, celery and database images to run in separate containers:
- A new config class (Decoupled) has been added to the python Flask config file
- The urls assigned in the Decoupled class match the container names assigned by docker-compose (defined in a separate repository)

Note: This configuration will mainly be used as a POC to explore networking and security solutions when running EAS components in isolated containers