### PR TITLE
EAS-824 Compose status url from service name

### DIFF
--- a/Dockerfile.eas-api
+++ b/Dockerfile.eas-api
@@ -1,5 +1,6 @@
 FROM 388086622185.dkr.ecr.eu-west-2.amazonaws.com/emergency-alerts-base:latest
 
+ENV SERVICE=api
 ENV VENV_API=/venv/eas-api
 ENV API_DIR=/eas/emergency-alerts-api
 

--- a/Dockerfile.eas-celery
+++ b/Dockerfile.eas-celery
@@ -1,5 +1,6 @@
 FROM 388086622185.dkr.ecr.eu-west-2.amazonaws.com/emergency-alerts-base:latest
 
+ENV SERVICE=celery
 ENV VENV_API=/venv/eas-api
 ENV API_DIR=/eas/emergency-alerts-api
 

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -3,7 +3,6 @@ from app.dao.organisation_dao import dao_count_organisations_with_live_services
 from app.dao.services_dao import dao_count_live_services
 
 from flask import Blueprint, jsonify, request
-from os import environ as env_var
 
 status = Blueprint("status", __name__)
 

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -9,7 +9,7 @@ status = Blueprint("status", __name__)
 
 @status.route("/", methods=["GET"])
 @status.route("/_api_status", methods=["GET", "POST"])
-def show_status():
+def show_api_status():
     if request.args.get("simple", None):
         return jsonify(status="ok"), 200
     else:
@@ -25,7 +25,7 @@ def show_status():
 
 
 @status.route("/_celery_status", methods=["GET", "POST"])
-def show_status():
+def show_celery_status():
     if request.args.get("simple", None):
         return jsonify(status="ok"), 200
     else:

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -24,7 +24,6 @@ def show_status():
         )
 
 
-@status.route("/", methods=["GET"])
 @status.route("/_celery_status", methods=["GET", "POST"])
 def show_status():
     if request.args.get("simple", None):
@@ -43,7 +42,7 @@ def show_status():
         )
 
 
-@status.route(status_endpoint + "/live-service-and-organisation-counts")
+@status.route("/_api_status/live-service-and-organisation-counts")
 def live_service_and_organisation_counts():
     return (
         jsonify(

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -7,11 +7,9 @@ from os import environ as env_var
 
 status = Blueprint("status", __name__)
 
-status_endpoint = "/_" + env_var.get("SERVICE") + "_status"
-
 
 @status.route("/", methods=["GET"])
-@status.route(status_endpoint, methods=["GET", "POST"])
+@status.route("/_api_status", methods=["GET", "POST"])
 def show_status():
     if request.args.get("simple", None):
         return jsonify(status="ok"), 200
@@ -22,6 +20,25 @@ def show_status():
                 git_commit=version.__git_commit__,
                 build_time=version.__time__,
                 db_version=get_db_version(),
+            ),
+            200,
+        )
+
+
+@status.route("/", methods=["GET"])
+@status.route("/_celery_status", methods=["GET", "POST"])
+def show_status():
+    if request.args.get("simple", None):
+        return jsonify(status="ok"), 200
+    else:
+        return (
+            jsonify(
+                # This is a placeholder health check
+                # This should be modified to check the celery queue for
+                # availability and correctness of function
+                status="ok",
+                git_commit=version.__git_commit__,
+                build_time=version.__time__,
             ),
             200,
         )

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -1,14 +1,17 @@
-from flask import Blueprint, jsonify, request
-
 from app import db, version
 from app.dao.organisation_dao import dao_count_organisations_with_live_services
 from app.dao.services_dao import dao_count_live_services
 
+from flask import Blueprint, jsonify, request
+from os import environ as env_var
+
 status = Blueprint("status", __name__)
+
+status_endpoint = "/_" + env_var.get("SERVICE") + "_status"
 
 
 @status.route("/", methods=["GET"])
-@status.route("/_status", methods=["GET", "POST"])
+@status.route(status_endpoint, methods=["GET", "POST"])
 def show_status():
     if request.args.get("simple", None):
         return jsonify(status="ok"), 200
@@ -24,7 +27,7 @@ def show_status():
         )
 
 
-@status.route("/_status/live-service-and-organisation-counts")
+@status.route(status_endpoint + "/live-service-and-organisation-counts")
 def live_service_and_organisation_counts():
     return (
         jsonify(


### PR DESCRIPTION
To allow the health check to not only confirm a healthy container, but also that a healthy container is  running the expected image, each service (api, celery & admin) should have a named health check:

- The 'status' route is modified to be specific to the image on which each container is based
- The api container has a health-check endpoint of '/_api_status'
- A celery-specific endpoint has also been added - '/_celery_status' to return the health of the queue when running the celery-beat container. Note: This is a placeholder and currently does not check the function of the celery queue.
