### PR TITLE
Update Broadcast Reference/Content While before Submission

### DIFF
--- a/app/broadcast_message/broadcast_message_schema.py
+++ b/app/broadcast_message/broadcast_message_schema.py
@@ -42,6 +42,8 @@ update_broadcast_message_schema = {
     "title": "Update broadcast_message",
     "properties": {
         "personalisation": {"type": "object"},
+        "reference": {"type": "string"},
+        "content": {"type": "string"},
         "starts_at": {"type": "string", "format": "datetime"},
         "finishes_at": {"type": "string", "format": "datetime"},
         "areas": {"type": "object"},

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -1,7 +1,6 @@
 import iso8601
 
 from botocore.exceptions import ClientError
-from emergency_alerts_utils.structured_logging import LogData, log_to_cloudwatch
 from emergency_alerts_utils.template import BroadcastMessageTemplate
 from flask import Blueprint, jsonify, request, current_app
 
@@ -118,6 +117,10 @@ def update_broadcast_message(service_id, broadcast_message_id):
 
     if "personalisation" in data:
         broadcast_message.personalisation = data["personalisation"]
+    if "reference" in data:
+        broadcast_message.reference = data["reference"]
+    if "content" in data:
+        broadcast_message.content = data["content"]
     if "starts_at" in data:
         broadcast_message.starts_at = _parse_nullable_datetime(data["starts_at"])
     if "finishes_at" in data:

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -1,6 +1,7 @@
 import iso8601
 
 from botocore.exceptions import ClientError
+from emergency_alerts_utils.structured_logging import LogData, log_to_cloudwatch
 from emergency_alerts_utils.template import BroadcastMessageTemplate
 from flask import Blueprint, jsonify, request, current_app
 

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -364,6 +364,8 @@ def test_update_broadcast_message_allows_edit_while_not_yet_live(admin_request, 
     response = admin_request.post(
         "broadcast_message.update_broadcast_message",
         _data={
+            "reference": "Emergency broadcast",
+            "content": "emergency broadcast content",
             "starts_at": "2020-06-01 20:00:01",
             "areas": {"ids": ["london", "glasgow"], "simple_polygons": [[[51.12, 0.2], [50.13, 0.4], [50.14, 0.45]]]},
         },
@@ -372,6 +374,8 @@ def test_update_broadcast_message_allows_edit_while_not_yet_live(admin_request, 
         _expected_status=200,
     )
 
+    assert response["reference"] == "Emergency broadcast"
+    assert response["content"] == "emergency broadcast content"
     assert response["starts_at"] == "2020-06-01T20:00:01.000000Z"
     assert response["areas"]["ids"] == ["london", "glasgow"]
     assert response["areas"]["simple_polygons"] == [[[51.12, 0.2], [50.13, 0.4], [50.14, 0.45]]]
@@ -395,8 +399,12 @@ def test_update_broadcast_message_doesnt_allow_edits_after_broadcast_goes_live(
 
     response = admin_request.post(
         "broadcast_message.update_broadcast_message",
-        _data={"areas": {"ids": ["london", "glasgow"]}},
-        service_id=t.service_id,
+        _data={
+            "reference": "Emergency broadcast",
+            "content": "emergency broadcast content",
+            "starts_at": "2020-06-01 20:00:01",
+            "areas": {"ids": ["london", "glasgow"], "simple_polygons": [[[51.12, 0.2], [50.13, 0.4], [50.14, 0.45]]]},
+        },        service_id=t.service_id,
         broadcast_message_id=bm.id,
         _expected_status=400,
     )

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -404,7 +404,8 @@ def test_update_broadcast_message_doesnt_allow_edits_after_broadcast_goes_live(
             "content": "emergency broadcast content",
             "starts_at": "2020-06-01 20:00:01",
             "areas": {"ids": ["london", "glasgow"], "simple_polygons": [[[51.12, 0.2], [50.13, 0.4], [50.14, 0.45]]]},
-        },        service_id=t.service_id,
+        },
+        service_id=t.service_id,
         broadcast_message_id=bm.id,
         _expected_status=400,
     )


### PR DESCRIPTION
Implemented as part of an accessibility/UX refinement for the alerts admin application, to retain broadcast reference/content state when moving backwards in the new broadcast flow.
While an alert is in a pre-submission state, users should be able to return to these fields and update them. Otherwise, they must rewrite these fields, which is confusing, time-consuming and does not provide a good user experience.