### PR TITLE
EAS-447 More changes to prepare for pipeline builds

### DIFF
--- a/Dockerfile.eas-api
+++ b/Dockerfile.eas-api
@@ -12,8 +12,8 @@ RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /e
     update-ca-certificates
 
 # Build emergency-alerts-api
-RUN $PYTHON_VERSION -m venv $VENV_API && . $VENV_API/bin/activate && \
-    pip3 install pycurl && cd $API_DIR && make bootstrap
+RUN $PYTHON_VERSION -m venv $VENV_API && cd $API_DIR && . $VENV_API/bin/activate && \
+    pip3 install pycurl && make bootstrap
 
 # Create a blank configuration file
 RUN echo "" > $API_DIR/environment.sh

--- a/Dockerfile.eas-celery
+++ b/Dockerfile.eas-celery
@@ -8,8 +8,8 @@ ENV API_DIR=/eas/emergency-alerts-api
 COPY . $API_DIR
 
 # Build emergency-alerts-api
-RUN $PYTHON_VERSION -m venv $VENV_API && . $VENV_API/bin/activate && \
-    pip3 install pycurl && cd $API_DIR && make bootstrap
+RUN $PYTHON_VERSION -m venv $VENV_API && cd $API_DIR && . $VENV_API/bin/activate && \
+    pip3 install pycurl && make bootstrap
 
 # Create a blank configuration file
 RUN echo "" > $API_DIR/environment.sh

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ legacy-bootstrap: generate-version-file ## Set up everything to run the app
 .PHONY: bootstrap
 bootstrap: generate-version-file ## Set up everything to run the app
 	pip3 install -r requirements_for_test.txt
+	pip3 install ../emergency-alerts-utils
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: ## Build the image to run the app in Docker

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ legacy-bootstrap: generate-version-file ## Set up everything to run the app
 .PHONY: bootstrap
 bootstrap: generate-version-file ## Set up everything to run the app
 	pip3 install -r requirements_for_test.txt
-	pip3 install ../emergency-alerts-utils
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: ## Build the image to run the app in Docker

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,7 +28,6 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy as _SQLAlchemy
 from gds_metrics import GDSMetrics
 from gds_metrics.metrics import Gauge, Histogram
-from moto import mock_rds
 from sqlalchemy import event
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
 from werkzeug.local import LocalProxy
@@ -81,7 +80,6 @@ CONCURRENT_REQUESTS = Gauge(
 )
 
 
-@mock_rds
 def create_app(application):
     from app.config import configs
 

--- a/app/config.py
+++ b/app/config.py
@@ -471,7 +471,7 @@ class ServerlessDB(Decoupled):
             port=os.environ.get("RDS_PORT"),
             database=os.environ.get("DATABASE"),
             user=os.environ.get("RDS_USER"),
-            cert='/etc/ssl/certs/global-bundle.pem',
+            cert="/etc/ssl/certs/global-bundle.pem",
         )
     )
     CBC_PROXY_ENABLED = True

--- a/requirements.in
+++ b/requirements.in
@@ -27,9 +27,6 @@ notifications-python-client==8.0.0
 
 -e file:../emergency-alerts-utils
 
-# PaaS
-# awscli-cwlogs==1.4.6
-
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72

--- a/requirements.in
+++ b/requirements.in
@@ -23,12 +23,10 @@ cachetools==5.2.0
 beautifulsoup4==4.11.1
 lxml==4.9.1
 
-notifications-python-client==6.3.0
+notifications-python-client==8.0.0
 
 # PaaS
 awscli-cwlogs==1.4.6
-
-emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.in
+++ b/requirements.in
@@ -25,8 +25,10 @@ lxml==4.9.1
 
 notifications-python-client==8.0.0
 
+-e file:../emergency-alerts-utils
+
 # PaaS
-awscli-cwlogs==1.4.6
+# awscli-cwlogs==1.4.6
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,18 +4,18 @@
 #
 #    pip-compile requirements.in
 #
+-e file:../emergency-alerts-utils
+    # via -r requirements.in
 alembic==1.8.1
     # via flask-migrate
 amqp==5.1.1
     # via kombu
 arrow==1.2.3
     # via isoduration
+async-timeout==4.0.2
+    # via redis
 attrs==22.1.0
     # via jsonschema
-awscli==1.25.85
-    # via awscli-cwlogs
-awscli-cwlogs==1.4.6
-    # via -r requirements.in
 bcrypt==4.0.0
     # via flask-bcrypt
 beautifulsoup4==4.11.1
@@ -24,16 +24,22 @@ billiard==3.6.4.0
     # via celery
 blinker==1.5
     # via gds-metrics
-botocore==1.27.84
+boto3==1.26.100
+    # via emergency-alerts-utils
+botocore==1.29.100
     # via
-    #   awscli
+    #   boto3
     #   s3transfer
 cachetools==5.2.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   emergency-alerts-utils
 celery[sqs]==5.2.7
     # via -r requirements.in
 certifi==2022.12.7
-    # via requests
+    # via
+    #   pyproj
+    #   requests
 cffi==1.15.1
     # via -r requirements.in
 charset-normalizer==2.1.1
@@ -54,22 +60,20 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-colorama==0.4.4
-    # via awscli
 dnspython==2.2.1
     # via eventlet
 docopt==0.6.2
     # via notifications-python-client
-docutils==0.16
-    # via awscli
 eventlet==0.33.1
     # via gunicorn
 flask==2.2.2
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask-bcrypt
     #   flask-marshmallow
     #   flask-migrate
+    #   flask-redis
     #   flask-sqlalchemy
     #   gds-metrics
 flask-bcrypt==1.0.1
@@ -78,6 +82,8 @@ flask-marshmallow==0.14.0
     # via -r requirements.in
 flask-migrate==3.1.0
     # via -r requirements.in
+flask-redis==0.4.0
+    # via emergency-alerts-utils
 flask-sqlalchemy==3.0.2
     # via
     #   -r requirements.in
@@ -86,6 +92,10 @@ fqdn==1.5.1
     # via jsonschema
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
+geojson==3.0.1
+    # via emergency-alerts-utils
+govuk-bank-holidays==0.13
+    # via emergency-alerts-utils
 greenlet==1.1.3
     # via eventlet
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
@@ -103,11 +113,16 @@ isoduration==20.11.0
 itsdangerous==2.1.2
     # via
     #   -r requirements.in
+    #   emergency-alerts-utils
     #   flask
 jinja2==3.1.2
-    # via flask
+    # via
+    #   emergency-alerts-utils
+    #   flask
 jmespath==1.0.1
-    # via botocore
+    # via
+    #   boto3
+    #   botocore
 jsonpointer==2.3
     # via jsonschema
 jsonschema[format]==4.16.0
@@ -130,12 +145,20 @@ marshmallow==3.18.0
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.28.1
     # via -r requirements.in
+mistune==0.8.4
+    # via emergency-alerts-utils
 notifications-python-client==8.0.0
     # via -r requirements.in
+numpy==1.24.2
+    # via shapely
+orderedset==2.0.3
+    # via emergency-alerts-utils
 packaging==21.3
     # via
     #   marshmallow
     #   marshmallow-sqlalchemy
+phonenumbers==8.13.8
+    # via emergency-alerts-utils
 prometheus-client==0.14.1
     # via
     #   -r requirements.in
@@ -144,8 +167,6 @@ prompt-toolkit==3.0.31
     # via click-repl
 psycopg2-binary==2.9.3
     # via -r requirements.in
-pyasn1==0.4.8
-    # via rsa
 pycparser==2.21
     # via cffi
 pyjwt==2.5.0
@@ -154,37 +175,48 @@ pyjwt==2.5.0
     #   notifications-python-client
 pyparsing==3.0.9
     # via packaging
+pypdf2==3.0.1
+    # via emergency-alerts-utils
+pyproj==3.4.0
+    # via emergency-alerts-utils
 pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via
     #   arrow
-    #   awscli-cwlogs
     #   botocore
+python-json-logger==2.0.7
+    # via emergency-alerts-utils
 pytz==2022.4
-    # via celery
+    # via
+    #   celery
+    #   emergency-alerts-utils
 pyyaml==5.4.1
-    # via awscli
+    # via emergency-alerts-utils
+redis==4.5.3
+    # via flask-redis
 requests==2.28.1
     # via
-    #   awscli-cwlogs
+    #   emergency-alerts-utils
+    #   govuk-bank-holidays
     #   notifications-python-client
 rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
     # via jsonschema
-rsa==4.7.2
-    # via awscli
 s3transfer==0.6.0
-    # via awscli
+    # via boto3
+shapely==2.0.1
+    # via emergency-alerts-utils
 six==1.16.0
     # via
-    #   awscli-cwlogs
     #   click-repl
     #   eventlet
     #   flask-marshmallow
     #   python-dateutil
     #   rfc3339-validator
+smartypants==2.0.1
+    # via emergency-alerts-utils
 soupsieve==2.3.2.post1
     # via beautifulsoup4
 sqlalchemy==1.4.41
@@ -193,6 +225,10 @@ sqlalchemy==1.4.41
     #   alembic
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
+statsd==4.0.1
+    # via emergency-alerts-utils
+typing-extensions==4.5.0
+    # via pypdf2
 uri-template==1.2.0
     # via jsonschema
 urllib3==1.26.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,6 @@ amqp==5.1.1
     # via kombu
 arrow==1.2.3
     # via isoduration
-async-timeout==4.0.2
-    # via redis
 attrs==22.1.0
     # via jsonschema
 awscli==1.25.85
@@ -26,23 +24,16 @@ billiard==3.6.4.0
     # via celery
 blinker==1.5
     # via gds-metrics
-boto3==1.24.84
-    # via emergency-alerts-utils
 botocore==1.27.84
     # via
     #   awscli
-    #   boto3
     #   s3transfer
 cachetools==5.2.0
-    # via
-    #   -r requirements.in
-    #   emergency-alerts-utils
+    # via -r requirements.in
 celery[sqs]==5.2.7
     # via -r requirements.in
 certifi==2022.12.7
-    # via
-    #   pyproj
-    #   requests
+    # via requests
 cffi==1.15.1
     # via -r requirements.in
 charset-normalizer==2.1.1
@@ -65,26 +56,20 @@ click-repl==0.2.0
     # via celery
 colorama==0.4.4
     # via awscli
-deprecated==1.2.13
-    # via redis
 dnspython==2.2.1
     # via eventlet
 docopt==0.6.2
     # via notifications-python-client
 docutils==0.16
     # via awscli
-emergency-alerts-utils @ git+https://github.com/alphagov/emergency-alerts-utils.git
-    # via -r requirements.in
 eventlet==0.33.1
     # via gunicorn
 flask==2.2.2
     # via
     #   -r requirements.in
-    #   emergency-alerts-utils
     #   flask-bcrypt
     #   flask-marshmallow
     #   flask-migrate
-    #   flask-redis
     #   flask-sqlalchemy
     #   gds-metrics
 flask-bcrypt==1.0.1
@@ -93,8 +78,6 @@ flask-marshmallow==0.14.0
     # via -r requirements.in
 flask-migrate==3.1.0
     # via -r requirements.in
-flask-redis==0.4.0
-    # via emergency-alerts-utils
 flask-sqlalchemy==3.0.2
     # via
     #   -r requirements.in
@@ -103,10 +86,6 @@ fqdn==1.5.1
     # via jsonschema
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
-geojson==2.5.0
-    # via emergency-alerts-utils
-govuk-bank-holidays==0.11
-    # via emergency-alerts-utils
 greenlet==1.1.3
     # via eventlet
 gunicorn @ git+https://github.com/benoitc/gunicorn.git@1299ea9e967a61ae2edebe191082fd169b864c64
@@ -124,16 +103,11 @@ isoduration==20.11.0
 itsdangerous==2.1.2
     # via
     #   -r requirements.in
-    #   emergency-alerts-utils
     #   flask
 jinja2==3.1.2
-    # via
-    #   emergency-alerts-utils
-    #   flask
+    # via flask
 jmespath==1.0.1
-    # via
-    #   boto3
-    #   botocore
+    # via botocore
 jsonpointer==2.3
     # via jsonschema
 jsonschema[format]==4.16.0
@@ -156,19 +130,12 @@ marshmallow==3.18.0
     #   marshmallow-sqlalchemy
 marshmallow-sqlalchemy==0.28.1
     # via -r requirements.in
-mistune==0.8.4
-    # via emergency-alerts-utils
-notifications-python-client==6.3.0
+notifications-python-client==8.0.0
     # via -r requirements.in
-orderedset==2.0.3
-    # via emergency-alerts-utils
 packaging==21.3
     # via
     #   marshmallow
     #   marshmallow-sqlalchemy
-    #   redis
-phonenumbers==8.12.56
-    # via emergency-alerts-utils
 prometheus-client==0.14.1
     # via
     #   -r requirements.in
@@ -187,10 +154,6 @@ pyjwt==2.5.0
     #   notifications-python-client
 pyparsing==3.0.9
     # via packaging
-pypdf2==2.11.0
-    # via emergency-alerts-utils
-pyproj==3.4.0
-    # via emergency-alerts-utils
 pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
@@ -198,23 +161,13 @@ python-dateutil==2.8.2
     #   arrow
     #   awscli-cwlogs
     #   botocore
-python-json-logger==2.0.4
-    # via emergency-alerts-utils
 pytz==2022.4
-    # via
-    #   celery
-    #   emergency-alerts-utils
+    # via celery
 pyyaml==5.4.1
-    # via
-    #   awscli
-    #   emergency-alerts-utils
-redis==4.3.4
-    # via flask-redis
+    # via awscli
 requests==2.28.1
     # via
     #   awscli-cwlogs
-    #   emergency-alerts-utils
-    #   govuk-bank-holidays
     #   notifications-python-client
 rfc3339-validator==0.1.4
     # via jsonschema
@@ -223,11 +176,7 @@ rfc3987==1.3.8
 rsa==4.7.2
     # via awscli
 s3transfer==0.6.0
-    # via
-    #   awscli
-    #   boto3
-shapely==1.8.4
-    # via emergency-alerts-utils
+    # via awscli
 six==1.16.0
     # via
     #   awscli-cwlogs
@@ -236,8 +185,6 @@ six==1.16.0
     #   flask-marshmallow
     #   python-dateutil
     #   rfc3339-validator
-smartypants==2.0.1
-    # via emergency-alerts-utils
 soupsieve==2.3.2.post1
     # via beautifulsoup4
 sqlalchemy==1.4.41
@@ -246,10 +193,6 @@ sqlalchemy==1.4.41
     #   alembic
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
-statsd==3.3.0
-    # via emergency-alerts-utils
-typing-extensions==4.4.0
-    # via pypdf2
 uri-template==1.2.0
     # via jsonschema
 urllib3==1.26.12
@@ -267,8 +210,6 @@ webcolors==1.12
     # via jsonschema
 werkzeug==2.2.2
     # via flask
-wrapt==1.14.1
-    # via deprecated
 zipp==3.11.0
     # via importlib-metadata
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -28,6 +28,7 @@ function docker_build(){
     --platform $PLATFORM \
     -t $ECS_ACCOUNT_NUMBER.dkr.ecr.$REGION.amazonaws.com/eas-app-$IMAGE:latest \
     -f Dockerfile.eas-$IMAGE \
+    --no-cache \
     $ARGS \
     .
 }


### PR DESCRIPTION
Further changes to support CI/CD pipeline:

- Utils should be installed from "local" - this folder is baked into the eas-app-base image, so it's existence is guaranteed
- Update notifications-python-client package reference, in anticipation of the Notify email and SMS integration
- Add --no-cache flag to buildx command to ensure the freshest dependencies are used to build the images
- Remove incorrect 'moto' mocking decorator
- Some formatting changes enforced by 'black'