### PR TITLE
EAS-576 Remove hard-coded account numbers from dockerfiles

### DIFF
--- a/Dockerfile.eas-api
+++ b/Dockerfile.eas-api
@@ -1,4 +1,4 @@
-FROM 388086622185.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
+FROM $ECS_ACCOUNT_NUMBER.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
 
 ENV SERVICE=api
 ENV VENV_API=/venv/eas-api

--- a/Dockerfile.eas-celery
+++ b/Dockerfile.eas-celery
@@ -1,4 +1,4 @@
-FROM 388086622185.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
+FROM $ECS_ACCOUNT_NUMBER.dkr.ecr.eu-west-2.amazonaws.com/eas-app-base:latest
 
 ENV SERVICE=celery
 ENV VENV_API=/venv/eas-api


### PR DESCRIPTION
Build script determines account number at build time - use this environment variable instead of hard-coding the account number.