### PR TITLE
EAS-994 Clean up "Add New Service" flow for Emergency Alerts

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -321,7 +321,6 @@ def bulk_invite_user_to_service(file_name, service_id, user_id, auth_type, permi
             "from_user": user_id,
             "permissions": permissions,
             "auth_type": auth_type,
-            # "invite_link_host": current_app.config["ADMIN_BASE_URL"],
             "invite_link_host": current_app.config["ADMIN_EXTERNAL_URL"],
         }
         with current_app.test_request_context(

--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import and_, asc, case, func
 
 from app import db
+from app.dao.broadcast_service_dao import set_broadcast_service_type
 from app.dao.dao_utils import VersionOptions, autocommit, version_class
 from app.dao.date_util import get_current_financial_year
 from app.dao.email_branding_dao import dao_get_email_branding_by_name
@@ -17,16 +18,12 @@ from app.dao.service_user_dao import dao_get_service_user
 from app.dao.template_folder_dao import dao_get_valid_template_folders_by_id
 from app.models import (
     CROWN_ORGANISATION_TYPES,
-    EMAIL_TYPE,
-    INTERNATIONAL_LETTERS,
-    INTERNATIONAL_SMS_TYPE,
     KEY_TYPE_TEST,
-    LETTER_TYPE,
     NHS_ORGANISATION_TYPES,
     NON_CROWN_ORGANISATION_TYPES,
     NOTIFICATION_PERMANENT_FAILURE,
     SMS_TYPE,
-    UPLOAD_LETTERS,
+    BROADCAST_TYPE,
     AnnualBilling,
     ApiKey,
     FactBilling,
@@ -57,12 +54,7 @@ from app.utils import (
 )
 
 DEFAULT_SERVICE_PERMISSIONS = [
-    SMS_TYPE,
-    EMAIL_TYPE,
-    LETTER_TYPE,
-    INTERNATIONAL_SMS_TYPE,
-    UPLOAD_LETTERS,
-    INTERNATIONAL_LETTERS,
+    BROADCAST_TYPE,
 ]
 
 
@@ -333,6 +325,7 @@ def dao_create_service(
     service.count_as_live = not user.platform_admin
 
     db.session.add(service)
+    set_broadcast_service_type(service, "training", "test", "all")
 
 
 @autocommit


### PR DESCRIPTION
Remove deprecated default service permissions and create a new service as a training-mode emergency alerts service.