### PR TITLE
EAS-487 Parse the domain in url creation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -377,7 +377,8 @@ class Development(Config):
 class Decoupled(Development):
     NOTIFY_ENVIRONMENT = "decoupled"
     ADMIN_BASE_URL = "http://admin.ecs.local:6012"
-    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
+    SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    ADMIN_EXTERNAL_URL = f"https://admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
     REDIS_URL = "redis://api.ecs.local:6379/0"
     API_HOST_NAME = "http://api.ecs.local:6011"
     TEMPLATE_PREVIEW_API_HOST = "http://api.ecs.local:6013"
@@ -448,7 +449,8 @@ class Test(Development):
 
     MMG_URL = "https://example.com/mmg"
     FIRETEXT_URL = "https://example.com/firetext"
-    ADMIN_EXTERNAL_URL = f"https://admin.{os.environ.get('ENVIRONMENT')}.emergency-alerts.service.gov.uk"
+    SUBDOMAIN = f"{os.environ.get('ENVIRONMENT')}." if os.environ.get("ENVIRONMENT") != "production" else ""
+    ADMIN_EXTERNAL_URL = f"https://admin.{SUBDOMAIN}emergency-alerts.service.gov.uk"
 
     CBC_PROXY_ENABLED = True
     DVLA_EMAIL_ADDRESSES = ["success@simulator.amazonses.com", "success+2@simulator.amazonses.com"]


### PR DESCRIPTION
When generating the URL that is passed out in the invitation, password-reset and other emails, the ENVIRONMENT should be checked to make sure the "production" domain isn't embedded in the URL.