### PR TITLE
CBC Lambdas can be called specifying account number

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,6 +38,9 @@ class Config(object):
     # URL of api app (on AWS this is the internal api endpoint)
     API_HOST_NAME = os.getenv("API_HOST_NAME")
 
+    # CBC Proxy AWS account number
+    CBC_ACCOUNT_NUMBER = os.getenv("CBC_ACCOUNT_NUMBER")
+
     # secrets that internal apps, such as the admin app or document download, must use to authenticate with the API
     ADMIN_CLIENT_ID = "notify-admin"
     GOVUK_ALERTS_CLIENT_ID = "govuk-alerts"

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -47,6 +47,7 @@ def cbc_proxy_client(client, mocker):
             "AWS_ACCESS_KEY_ID": "cbc-proxy-aws-access-key-id",
             "CBC_PROXY_AWS_SECRET_ACCESS_KEY": "cbc-proxy-aws-secret-access-key",
             "AWS_SECRET_ACCESS_KEY": "cbc-proxy-aws-secret-access-key",
+            "CBC_ACCOUNT_NUMBER": None,
             "CBC_PROXY_ENABLED": True,
         }
     )


### PR DESCRIPTION
Currently, the application attempts to call the proxy lambdas in the same account, because only the name of the function is specified. This accommodates an environment variable to specify which account the Lambdas should be called in. Obviously, it will only be able to trigger Lambdas that the application is authorised to trigger.