### PR TITLE
EAS-1089 Implement govuk-alerts healthcheck celery beat task

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -42,16 +42,17 @@ class CBCProxyClient:
     def init_app(self, app):
         if app.config.get("CBC_PROXY_ENABLED"):
             if app.config.get("CBC_ACCOUNT_NUMBER") is not None:
-                self._arn_prefix = (app.config.get("CBC_ACCOUNT_NUMBER") + ":function:")
-            self._lambda_client = boto3.client(
-                "lambda",
-                region_name="eu-west-2",
-                aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
-                aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
-                aws_session_token=os.environ.get("AWS_SESSION_TOKEN"),
-            ) if app.config.get("NOTIFY_ENVIRONMENT") == "development" else boto3.client(
-                "lambda",
-                region_name="eu-west-2"
+                self._arn_prefix = app.config.get("CBC_ACCOUNT_NUMBER") + ":function:"
+            self._lambda_client = (
+                boto3.client(
+                    "lambda",
+                    region_name="eu-west-2",
+                    aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+                    aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+                    aws_session_token=os.environ.get("AWS_SESSION_TOKEN"),
+                )
+                if app.config.get("NOTIFY_ENVIRONMENT") == "development"
+                else boto3.client("lambda", region_name="eu-west-2")
             )
 
     def get_proxy(self, provider):

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class QueueNames(object):
 
 class TaskNames(object):
     PUBLISH_GOVUK_ALERTS = "publish-govuk-alerts"
+    TRIGGER_GOVUK_HEALTHCHECK = "trigger-govuk-alerts-healthcheck"
 
 
 class BroadcastProvider:
@@ -153,6 +154,11 @@ class Config(object):
                 "task": "run-health-check",
                 "schedule": crontab(minute="*/1"),
                 "options": {"queue": QueueNames.PERIODIC},
+            },
+            TaskNames.TRIGGER_GOVUK_HEALTHCHECK: {
+                "task": TaskNames.TRIGGER_GOVUK_HEALTHCHECK,
+                "schedule": crontab(minute="*/1"),
+                "options": {"queue": QueueNames.GOVUK_ALERTS},
             },
             "trigger-link-tests": {
                 "task": "trigger-link-tests",


### PR DESCRIPTION
Celery beat should queue up a period task to be picked up by the govuk-alerts celery worker, to update the health-check timestamp file, used by the AWS govuk-alerts container.