### PR TITLE
Default services to allow broadcast

### DIFF
--- a/app/dao/services_dao.py
+++ b/app/dao/services_dao.py
@@ -16,6 +16,7 @@ from app.dao.service_sms_sender_dao import insert_service_sms_sender
 from app.dao.service_user_dao import dao_get_service_user
 from app.dao.template_folder_dao import dao_get_valid_template_folders_by_id
 from app.models import (
+    BROADCAST_TYPE,
     CROWN_ORGANISATION_TYPES,
     EMAIL_TYPE,
     INTERNATIONAL_LETTERS,
@@ -57,6 +58,7 @@ from app.utils import (
 )
 
 DEFAULT_SERVICE_PERMISSIONS = [
+    BROADCAST_TYPE,
     SMS_TYPE,
     EMAIL_TYPE,
     LETTER_TYPE,

--- a/app/platform_admin/rest.py
+++ b/app/platform_admin/rest.py
@@ -1,0 +1,104 @@
+from contextlib import suppress
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy.exc import NoResultFound
+
+from app import db
+from app.errors import register_errors
+from app.models import (
+    ApiKey,
+    Complaint,
+    EmailBranding,
+    InboundNumber,
+    InboundSms,
+    Job,
+    LetterBranding,
+    Notification,
+    Organisation,
+    ProviderDetails,
+    Service,
+    ServiceCallbackApi,
+    ServiceContactList,
+    ServiceDataRetention,
+    ServiceEmailReplyTo,
+    ServiceInboundApi,
+    ServiceSmsSender,
+    Template,
+    TemplateFolder,
+    User,
+)
+
+platform_admin_blueprint = Blueprint("platform_admin", __name__)
+register_errors(platform_admin_blueprint)
+
+FIND_BY_UUID_MODELS = {
+    "organisation": Organisation,
+    "service": Service,
+    "template": Template,
+    "notification": Notification,
+    "email_branding": EmailBranding,
+    "letter_branding": LetterBranding,
+    "user": User,
+    "provider": ProviderDetails,
+    "reply_to_email": ServiceEmailReplyTo,
+    "job": Job,
+    "service_contact_list": ServiceContactList,
+    "service_data_retention": ServiceDataRetention,
+    "service_sms_sender": ServiceSmsSender,
+    "inbound_number": InboundNumber,
+    "api_key": ApiKey,
+    "template_folder": TemplateFolder,
+    "service_inbound_api": ServiceInboundApi,
+    "service_callback_api": ServiceCallbackApi,
+    "complaint": Complaint,
+    "inbound_sms": InboundSms,
+}
+
+# The `context` here is actually information required by the admin app to build the redirect URL. This does mean
+# that this endpoint and the admin search page are fairly closely coupled. We could serialize the entire object
+# back, which might be more consistent with how other endpoints return representations of objects, but for many
+# objects we don't need any information at all, and our serialization of objects is already inconsistently between
+# `instance.serialize` and `some_schema.dump(instance)`. And not all of the serialized representations of objects
+# expose the field we need anyway (which is, as of writing, invariably the related service id).
+FIND_BY_UUID_EXTRA_CONTEXT = {
+    "template": {"service_id"},
+    "notification": {"service_id"},
+    "reply_to_email": {"service_id"},
+    "job": {"service_id"},
+    "service_contact_list": {"service_id"},
+    "service_data_retention": {"service_id"},
+    "service_sms_sender": {"service_id"},
+    "api_key": {"service_id"},
+    "template_folder": {"service_id"},
+    "service_inbound_api": {"service_id"},
+    "service_callback_api": {"service_id"},
+    "inbound_sms": {"service_id"},
+}
+
+
+def _find_model_by_uuid(uuid_: str) -> tuple[db.Model, str]:
+    for entity_name, model in FIND_BY_UUID_MODELS.items():
+        with suppress(NoResultFound):
+            if instance := model.query.get(uuid_):
+                return instance, entity_name
+
+    raise NoResultFound
+
+
+@platform_admin_blueprint.route("/find-by-uuid", methods=["POST"])
+def find_by_uuid():
+    """Provides a simple interface for looking whether a UUID references any common DB objects"""
+    instance, entity_name = _find_model_by_uuid(request.json["uuid"])
+
+    return (
+        jsonify(
+            {
+                "type": entity_name,
+                "context": {
+                    field_name: getattr(instance, field_name)
+                    for field_name in FIND_BY_UUID_EXTRA_CONTEXT.get(entity_name, set())
+                },
+            }
+        ),
+        200,
+    )

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -43,6 +43,7 @@ from app.dao.services_dao import (
 )
 from app.dao.users_dao import create_user_code, save_model_user
 from app.models import (
+    BROADCAST_TYPE,
     EMAIL_TYPE,
     INTERNATIONAL_LETTERS,
     INTERNATIONAL_SMS_TYPE,
@@ -554,15 +555,29 @@ def test_create_service_returns_service_with_default_permissions(notify_db_sessi
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        (
+            BROADCAST_TYPE,
+            SMS_TYPE,
+            EMAIL_TYPE,
+            LETTER_TYPE,
+            INTERNATIONAL_SMS_TYPE,
+            UPLOAD_LETTERS,
+            INTERNATIONAL_LETTERS,
+        ),
     )
 
 
 @pytest.mark.parametrize(
     "permission_to_remove, permissions_remaining",
     [
-        (SMS_TYPE, (EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)),
-        (EMAIL_TYPE, (SMS_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)),
+        (
+            SMS_TYPE,
+            (EMAIL_TYPE, BROADCAST_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        ),
+        (
+            EMAIL_TYPE,
+            (SMS_TYPE, BROADCAST_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        ),
     ],
 )
 def test_remove_permission_from_service_by_id_returns_service_with_correct_permissions(
@@ -577,6 +592,7 @@ def test_remove_permission_from_service_by_id_returns_service_with_correct_permi
 
 def test_removing_all_permission_returns_service_with_no_permissions(notify_db_session):
     service = create_service()
+    dao_remove_service_permission(service_id=service.id, permission=BROADCAST_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=SMS_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=EMAIL_TYPE)
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
@@ -597,14 +613,23 @@ def test_create_service_by_id_adding_and_removing_letter_returns_service_without
     service = dao_fetch_service_by_id(service.id)
     _assert_service_permissions(
         service.permissions,
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
+        (
+            BROADCAST_TYPE,
+            SMS_TYPE,
+            EMAIL_TYPE,
+            LETTER_TYPE,
+            INTERNATIONAL_SMS_TYPE,
+            UPLOAD_LETTERS,
+            INTERNATIONAL_LETTERS,
+        ),
     )
 
     dao_remove_service_permission(service_id=service.id, permission=LETTER_TYPE)
     service = dao_fetch_service_by_id(service.id)
 
     _assert_service_permissions(
-        service.permissions, (SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)
+        service.permissions,
+        (BROADCAST_TYPE, SMS_TYPE, EMAIL_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS),
     )
 
 
@@ -746,7 +771,15 @@ def test_delete_service_and_associated_objects(notify_db_session):
     user.organisations = [organisation]
 
     assert ServicePermission.query.count() == len(
-        (SMS_TYPE, EMAIL_TYPE, LETTER_TYPE, INTERNATIONAL_SMS_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS)
+        (
+            BROADCAST_TYPE,
+            SMS_TYPE,
+            EMAIL_TYPE,
+            LETTER_TYPE,
+            INTERNATIONAL_SMS_TYPE,
+            UPLOAD_LETTERS,
+            INTERNATIONAL_LETTERS,
+        )
     )
 
     delete_service_and_all_associated_db_objects(service)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -309,7 +309,15 @@ def test_get_service_list_has_default_permissions(admin_request, service_factory
     assert len(json_resp["data"]) == 3
     assert all(
         set(json["permissions"])
-        == {EMAIL_TYPE, SMS_TYPE, INTERNATIONAL_SMS_TYPE, LETTER_TYPE, UPLOAD_LETTERS, INTERNATIONAL_LETTERS}
+        == {
+            BROADCAST_TYPE,
+            EMAIL_TYPE,
+            SMS_TYPE,
+            INTERNATIONAL_SMS_TYPE,
+            LETTER_TYPE,
+            UPLOAD_LETTERS,
+            INTERNATIONAL_LETTERS,
+        }
         for json in json_resp["data"]
     )
 
@@ -318,6 +326,7 @@ def test_get_service_by_id_has_default_service_permissions(admin_request, sample
     json_resp = admin_request.get("service.get_service_by_id", service_id=sample_service.id)
 
     assert set(json_resp["data"]["permissions"]) == {
+        BROADCAST_TYPE,
         EMAIL_TYPE,
         SMS_TYPE,
         INTERNATIONAL_SMS_TYPE,

--- a/tests/app/test_commands.py
+++ b/tests/app/test_commands.py
@@ -32,5 +32,5 @@ def test_local_dev_broadcast_permissions(
 
     notify_api.test_cli_runner().invoke(local_dev_broadcast_permissions, ["-u", user.id])
 
-    assert len(user.get_permissions(sample_service.id)) == 0
+    assert len(user.get_permissions(sample_service.id)) == 6
     assert len(user.get_permissions(sample_broadcast_service.id)) > 0

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -6,6 +6,12 @@ from flask import json
 from app.dao.broadcast_message_dao import (
     dao_get_broadcast_message_by_id_and_service_id,
 )
+from app.dao.service_permissions_dao import (
+    dao_remove_service_permission,
+)
+from app.models import (
+    BROADCAST_TYPE,
+)
 from tests import create_service_authorization_header
 from tests.app.db import create_api_key
 
@@ -16,6 +22,7 @@ def test_broadcast_for_service_without_permission_returns_400(
     client,
     sample_service,
 ):
+    dao_remove_service_permission(service_id=sample_service.id, permission=BROADCAST_TYPE)
     auth_header = create_service_authorization_header(service_id=sample_service.id)
     response = client.post(
         path="/v2/broadcast",

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -6,12 +6,8 @@ from flask import json
 from app.dao.broadcast_message_dao import (
     dao_get_broadcast_message_by_id_and_service_id,
 )
-from app.dao.service_permissions_dao import (
-    dao_remove_service_permission,
-)
-from app.models import (
-    BROADCAST_TYPE,
-)
+from app.dao.service_permissions_dao import dao_remove_service_permission
+from app.models import BROADCAST_TYPE
 from tests import create_service_authorization_header
 from tests.app.db import create_api_key
 


### PR DESCRIPTION
Services default to having broadcast permissions, to resolve the "Page not found" issue for created services - all services in Emergency Alerts will require broadcast permissions.
It also adds an API endpoint for searching for objects by UUID, similar to this feature in Notify: https://github.com/alphagov/notifications-api/commit/5ff4d2730b45427c64d628bac319c57e64b9c1fc
Relates to: https://github.com/alphagov/emergency-alerts-admin/pull/64