### PR TITLE
Add migration to update organisation name

### DIFF
--- a/migrations/versions/0389_org_to_emergency_alerts.py
+++ b/migrations/versions/0389_org_to_emergency_alerts.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 0389_org_to_emergency_alerts
+Revises: 0388_populate_letter_branding
+Create Date: 2023-06-23 17:14:12:01.094412
+
+"""
+from alembic import op
+
+revision = "0389_org_to_emergency_alerts"
+down_revision = "0388_populate_letter_branding"
+
+organisation_id = "38e4bf69-93b0-445d-acee-53ea53fe02df"
+
+
+def upgrade():
+    op.execute(
+        """
+            UPDATE
+                organisation
+            SET
+                name = 'Emergency Alerts'
+            WHERE
+                name = :id;
+        """,
+        id=organisation_id,
+    )
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Based on this migration:
https://github.com/alphagov/emergency-alerts-api/commit/aac6b16b3c532d74d788cbad942af6a147a06f4b

The purpose of this to update the organisation name from Broadcast Service (environment_name) to Emergency Alerts due to the nature of Emergency Alerts, we don't use multiple organisations, just multiple services.