### PR TITLE
Block invocation of secondary lambda in EE's staging environment

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -139,7 +139,10 @@ class CBCProxyClientBase(ABC):
             except ClientError as e:
                 current_app.logger.info("Error writing to CloudWatch: %s", e)
 
-            failover_result = self._invoke_lambda(self.failover_lambda_name, payload)
+            failover_result = None
+            if self.failover_lambda_name is not None:
+                failover_result = self._invoke_lambda(self.failover_lambda_name, payload)
+
             if not failover_result:
                 try:
                     logData = LogData(source="eas-app-api", module="cbc_proxy", method="_invoke_lambda_with_failover")
@@ -241,7 +244,7 @@ class CBCProxyOne2ManyClient(CBCProxyClientBase):
 
 class CBCProxyEE(CBCProxyOne2ManyClient):
     lambda_name = "ee-1-proxy"
-    failover_lambda_name = "ee-2-proxy"
+    failover_lambda_name = "ee-2-proxy" if os.environ.get("ENVIRONMENT") != "staging" else None
 
 
 class CBCProxyThree(CBCProxyOne2ManyClient):


### PR DESCRIPTION
EE don't have a failover lambda in their staging environment
- This PR defines a check to ensure the lambda isn't invoked, reducing errors