### PR TITLE
EAS-1865 Purging Test Alerts on Preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ run-celery: ## Run celery
 		--prefetch-multiplier=1 \
 		--loglevel=WARNING \
 		--concurrency=1 \
-		--autoscale=1,1
+		--autoscale=1,1 \
 		--hostname=0.0.0.0
 
 .PHONY: run-celery-with-docker

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -191,7 +191,7 @@ def update_broadcast_message_status(service_id, broadcast_message_id):
 
 
 @broadcast_message_blueprint.route("/purge/<int:older_than>", methods=["GET"])
-def get_latest_verify_code_for_user(older_than):
+def purge_broadcast_messages(older_than):
     if is_public_environment():
         raise InvalidRequest("Endpoint not found", status_code=404)
 

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -195,4 +195,15 @@ def get_latest_verify_code_for_user(older_than):
     if is_public_environment():
         raise InvalidRequest("Endpoint not found", status_code=404)
 
-    return dao_purge_old_broadcast_messages(days_older_than=older_than)
+    try:
+        count = dao_purge_old_broadcast_messages(days_older_than=older_than)
+    except Exception as e:
+        return jsonify(result="error", message=f"Unable to purge old alert items: {e}"), 500
+
+    return (
+        jsonify(
+            f"Successfully purged {len(count.msgs)} BroadcastMessage items and \
+        {len(count.events)} BroadcastEvent items, created more than {older_than} days ago"
+        ),
+        200,
+    )

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -191,19 +191,21 @@ def update_broadcast_message_status(service_id, broadcast_message_id):
 
 
 @broadcast_message_blueprint.route("/purge/<int:older_than>", methods=["GET"])
-def purge_broadcast_messages(older_than):
+def purge_broadcast_messages(service_id, older_than):
     if is_public_environment():
         raise InvalidRequest("Endpoint not found", status_code=404)
 
     try:
-        count = dao_purge_old_broadcast_messages(days_older_than=older_than)
+        count = dao_purge_old_broadcast_messages(service=service_id, days_older_than=older_than)
     except Exception as e:
         return jsonify(result="error", message=f"Unable to purge old alert items: {e}"), 500
 
     return (
         jsonify(
-            f"Successfully purged {len(count.msgs)} BroadcastMessage items and \
-        {len(count.events)} BroadcastEvent items, created more than {older_than} days ago"
+            {
+                "message": f"Purged {count['msgs']} BroadcastMessage items and {count['events']} "
+                f"BroadcastEvent items, created more than {older_than} days ago"
+            }
         ),
         200,
     )

--- a/app/commands.py
+++ b/app/commands.py
@@ -964,6 +964,7 @@ def generate_bulktest_data(user_id):
     pprint("Finished.")
 
 
+@notify_command(name="purge-alerts")
 @click.option(
     "-o",
     "--older-than",
@@ -978,7 +979,6 @@ def generate_bulktest_data(user_id):
     default=None,
     help="""Service identifier - can be either the service UUID or the service name""",
 )
-@notify_command(name="purge-alerts")
 def purge_alerts_from_db(older_than, service_identifier):
     if os.environ.get("ENVIRONMENT") != "preview":
         print("Alerts can only be removed from the database db in development and preview environments")

--- a/app/commands.py
+++ b/app/commands.py
@@ -983,6 +983,7 @@ def generate_bulktest_data(user_id):
     "-d",
     "--dry-run",
     required=False,
+    default=False,
     type=bool,
     help="""Show the IDs of the DB items selected only. The items will not be deleted""",
 )
@@ -990,6 +991,6 @@ def purge_alerts_from_db(older_than, service, dry_run):
     if os.environ.get("ENVIRONMENT") != "preview":
         print("Alerts can only be removed from the database db in development and preview environments")
 
-    print(f"Purging alerts over {older_than} days old...")
+    print(f">>>>>> Purging alerts over {older_than} days old...")
     dao_purge_old_broadcast_messages(days_older_than=older_than, service=service, dry_run=dry_run)
-    print("Purge complete")
+    print("<<<<<< Purge complete")

--- a/app/commands.py
+++ b/app/commands.py
@@ -26,6 +26,7 @@ from app.dao.annual_billing_dao import (
     dao_create_or_update_annual_billing_for_year,
     set_default_free_allowance_for_service,
 )
+from app.dao.broadcast_message_dao import dao_purge_old_broadcast_messages
 from app.dao.fact_billing_dao import (
     delete_billing_data_for_services_for_day,
     fetch_billing_data_for_day,
@@ -961,3 +962,20 @@ def generate_bulktest_data(user_id):
     pprint("Committing...")
     db.session.commit()
     pprint("Finished.")
+
+
+@click.option(
+    "-o",
+    "--older-than",
+    required=False,
+    type=int,
+    help="""Alerts older than the provided value (in days) will be purged from the database""",
+)
+@notify_command(name="purge-alerts")
+def purge_alerts_from_db(older_than):
+    if os.environ.get("ENVIRONMENT") != "preview":
+        print("Alerts can only be removed from the database db in development and preview environments")
+
+    print("Purging alerts over {older_than} days old...")
+    dao_purge_old_broadcast_messages(days_older_than=older_than)
+    print("Purge complete")

--- a/app/commands.py
+++ b/app/commands.py
@@ -994,6 +994,6 @@ def purge_alerts_from_db(older_than, service, dry_run):
     print(f">>>>>> Purging alerts over {older_than} days old...")
     count = dao_purge_old_broadcast_messages(service=service, days_older_than=older_than, dry_run=dry_run)
     print(
-        f"<<<<<< Successfully purged {len(count['msgs'])} BroadcastMessage items and {len(count['events'])} \
+        f"<<<<<< Successfully purged {count['msgs']} BroadcastMessage items and {count['events']} \
         BroadcastEvent items, created more than {older_than} days ago"
     )

--- a/app/commands.py
+++ b/app/commands.py
@@ -994,6 +994,6 @@ def purge_alerts_from_db(older_than, service, dry_run):
     print(f">>>>>> Purging alerts over {older_than} days old...")
     count = dao_purge_old_broadcast_messages(service=service, days_older_than=older_than, dry_run=dry_run)
     print(
-        f"<<<<<< Successfully purged {len(count.msgs)} BroadcastMessage items and {len(count.events)} \
+        f"<<<<<< Successfully purged {len(count['msgs'])} BroadcastMessage items and {len(count['events'])} \
         BroadcastEvent items, created more than {older_than} days ago"
     )

--- a/app/commands.py
+++ b/app/commands.py
@@ -983,6 +983,6 @@ def purge_alerts_from_db(older_than, service):
     if os.environ.get("ENVIRONMENT") != "preview":
         print("Alerts can only be removed from the database db in development and preview environments")
 
-    print("Purging alerts over {older_than} days old...")
+    print(f"Purging alerts over {older_than} days old...")
     dao_purge_old_broadcast_messages(days_older_than=older_than, service=service)
     print("Purge complete")

--- a/app/commands.py
+++ b/app/commands.py
@@ -988,8 +988,8 @@ def generate_bulktest_data(user_id):
     help="""Show the IDs of the DB items selected only. The items will not be deleted""",
 )
 def purge_alerts_from_db(older_than, service, dry_run):
-    if os.environ.get("ENVIRONMENT") != "preview":
-        print("Alerts can only be removed from the database db in development and preview environments")
+    if os.environ.get("ENVIRONMENT") not in ["local", "development", "preview"]:
+        print("Alerts can only be removed from the database db in local, development and preview environments")
 
     print(f"Purging alerts over {older_than} days old...")
     count = dao_purge_old_broadcast_messages(service=service, days_older_than=older_than, dry_run=dry_run)

--- a/app/commands.py
+++ b/app/commands.py
@@ -992,5 +992,8 @@ def purge_alerts_from_db(older_than, service, dry_run):
         print("Alerts can only be removed from the database db in development and preview environments")
 
     print(f">>>>>> Purging alerts over {older_than} days old...")
-    dao_purge_old_broadcast_messages(days_older_than=older_than, service=service, dry_run=dry_run)
-    print("<<<<<< Purge complete")
+    count = dao_purge_old_broadcast_messages(days_older_than=older_than, service=service, dry_run=dry_run)
+    print(
+        f"<<<<<< Successfully purged {len(count.msgs)} BroadcastMessage items and {len(count.events)} \
+        BroadcastEvent items, created more than {older_than} days ago"
+    )

--- a/app/commands.py
+++ b/app/commands.py
@@ -991,9 +991,15 @@ def purge_alerts_from_db(older_than, service, dry_run):
     if os.environ.get("ENVIRONMENT") != "preview":
         print("Alerts can only be removed from the database db in development and preview environments")
 
-    print(f">>>>>> Purging alerts over {older_than} days old...")
+    print(f"Purging alerts over {older_than} days old...")
     count = dao_purge_old_broadcast_messages(service=service, days_older_than=older_than, dry_run=dry_run)
-    print(
-        f"<<<<<< Successfully purged {count['msgs']} BroadcastMessage items and {count['events']} \
-        BroadcastEvent items, created more than {older_than} days ago"
-    )
+    if dry_run:
+        print(
+            f"Items found for purging:\n \
+            BroadcastMessage: {count['msgs']}\n \
+            BroadcastEvent: {count['events']}\n \
+            BroadcastProviderMessage: {count['provider_msgs']}\n \
+            BroadcastProviderMessageNumber: {count['msg_numbers']}"
+        )
+    else:
+        print(f"Successfully purged {count['msgs']} broadcast messages")

--- a/app/commands.py
+++ b/app/commands.py
@@ -979,10 +979,10 @@ def generate_bulktest_data(user_id):
     default=None,
     help="""Service identifier - can be either the service UUID or the service name""",
 )
-def purge_alerts_from_db(older_than, service_identifier):
+def purge_alerts_from_db(older_than, service):
     if os.environ.get("ENVIRONMENT") != "preview":
         print("Alerts can only be removed from the database db in development and preview environments")
 
     print("Purging alerts over {older_than} days old...")
-    dao_purge_old_broadcast_messages(days_older_than=older_than, service=service_identifier)
+    dao_purge_old_broadcast_messages(days_older_than=older_than, service=service)
     print("Purge complete")

--- a/app/commands.py
+++ b/app/commands.py
@@ -979,10 +979,17 @@ def generate_bulktest_data(user_id):
     default=None,
     help="""Service identifier - can be either the service UUID or the service name""",
 )
-def purge_alerts_from_db(older_than, service):
+@click.option(
+    "-d",
+    "--dry-run",
+    required=False,
+    type=bool,
+    help="""Show the IDs of the DB items selected only. The items will not be deleted""",
+)
+def purge_alerts_from_db(older_than, service, dry_run):
     if os.environ.get("ENVIRONMENT") != "preview":
         print("Alerts can only be removed from the database db in development and preview environments")
 
     print(f"Purging alerts over {older_than} days old...")
-    dao_purge_old_broadcast_messages(days_older_than=older_than, service=service)
+    dao_purge_old_broadcast_messages(days_older_than=older_than, service=service, dry_run=dry_run)
     print("Purge complete")

--- a/app/commands.py
+++ b/app/commands.py
@@ -971,11 +971,18 @@ def generate_bulktest_data(user_id):
     type=int,
     help="""Alerts older than the provided value (in days) will be purged from the database""",
 )
+@click.option(
+    "-s",
+    "--service",
+    required=False,
+    default=None,
+    help="""Service identifier - can be either the service UUID or the service name""",
+)
 @notify_command(name="purge-alerts")
-def purge_alerts_from_db(older_than):
+def purge_alerts_from_db(older_than, service_identifier):
     if os.environ.get("ENVIRONMENT") != "preview":
         print("Alerts can only be removed from the database db in development and preview environments")
 
     print("Purging alerts over {older_than} days old...")
-    dao_purge_old_broadcast_messages(days_older_than=older_than)
+    dao_purge_old_broadcast_messages(days_older_than=older_than, service=service_identifier)
     print("Purge complete")

--- a/app/commands.py
+++ b/app/commands.py
@@ -992,7 +992,7 @@ def purge_alerts_from_db(older_than, service, dry_run):
         print("Alerts can only be removed from the database db in development and preview environments")
 
     print(f">>>>>> Purging alerts over {older_than} days old...")
-    count = dao_purge_old_broadcast_messages(days_older_than=older_than, service=service, dry_run=dry_run)
+    count = dao_purge_old_broadcast_messages(service=service, days_older_than=older_than, dry_run=dry_run)
     print(
         f"<<<<<< Successfully purged {len(count.msgs)} BroadcastMessage items and {len(count.events)} \
         BroadcastEvent items, created more than {older_than} days ago"

--- a/app/config.py
+++ b/app/config.py
@@ -272,6 +272,9 @@ class Config(object):
 
     DVLA_EMAIL_ADDRESSES = ["success@simulator.amazonses.com"]
 
+    FUNCTIONAL_TESTS_BROADCAST_SERVICE_NAME = "Functional Tests Broadcast Service"
+    FUNCTIONAL_TESTS_BROADCAST_SERVICE_ID = "8e1d56fa-12a8-4d00-bed2-db47180bed0a"
+
 
 class Hosted(Config):
     HOST = "hosted"

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -93,7 +93,8 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     print(f"Purging alerts for service {service_id}")
 
     messages = _get_broadcast_messages(days_older_than, service_id)
-    print(f"Messages associated with service {service_id}: " + messages)
+    print(f"Messages associated with service {service_id}:")
+    print(messages)
 
     for message in messages:
         try:

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -120,25 +120,22 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     print(messages)
 
     for message in messages:
-        #  transaction = session.begin()
         try:
-            bms = session.query(BroadcastMessage).filter_by(id=message.id)
-            print(bms)
-            session.query(BroadcastMessage).filter_by(id=message.id).delete(synchronize_session=False)
-
-            bpms = (
+            broadcast_provider_messages = (
                 session.query(BroadcastProviderMessage)
                 .join(BroadcastEvent, BroadcastProviderMessage.broadcast_event_id == BroadcastEvent.id)
                 .filter(BroadcastEvent.broadcast_message_id == message.id)
             )
-            print(bpms)
-            session.query(BroadcastProviderMessage).join(
-                BroadcastEvent, BroadcastProviderMessage.broadcast_event_id == BroadcastEvent.id
-            ).filter(BroadcastEvent.broadcast_message_id == message.id).delete(synchronize_session=False)
+            print(broadcast_provider_messages)
+            broadcast_provider_messages.delete(synchronize_session=False)
 
-            bes = session.query(BroadcastEvent).filter_by(broadcast_message_id=message.id)
-            print(bes)
-            session.query(BroadcastEvent).filter_by(broadcast_message_id=message.id).delete(synchronize_session=False)
+            broadcast_events = session.query(BroadcastEvent).filter_by(broadcast_message_id=message.id)
+            print(broadcast_events)
+            broadcast_events.delete(synchronize_session=False)
+
+            broadcast_messages = session.query(BroadcastMessage).filter_by(id=message.id)
+            print(broadcast_messages)
+            broadcast_messages.delete(synchronize_session=False)
 
             session.commit()
         except Exception as e:

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -86,14 +86,14 @@ def dao_get_all_broadcast_messages():
     )
 
 
-def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=True):
+def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=False):
     service_id = _resolve_service_id(service)
     if service_id is None:
         raise "Unable to find service ID"
-    print(f">>> Purging alerts for service {service_id}")
+    print(f"Purging alerts for service {service_id}")
 
     message_ids = _get_broadcast_messages(days_older_than, service_id)
-    print(f">>> Messages to purge, associated with service {service_id}:")
+    print(f"Messages to purge, associated with service {service_id}:")
     print("\n".join(message_ids))
 
     for message_id in message_ids:
@@ -102,7 +102,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=T
 
             broadcast_event_rows = db.session.query(BroadcastEvent.id).filter_by(broadcast_message_id=message_id).all()
             broadcast_event_ids = [str(row[0]) for row in broadcast_event_rows]
-            print(f">>> BroadcastEvent IDs associated with messsage {message_id}:")
+            print(f"BroadcastEvent IDs associated with messsage {message_id}:")
             if len(broadcast_event_ids):
                 print("\n".join(broadcast_event_ids))
             else:
@@ -115,7 +115,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=T
             )
             broadcast_provider_message_ids = [str(row[0]) for row in broadcast_provider_message_rows]
 
-            print(">>> BroadcastProviderMessage IDs associated with BroadcastEvents:")
+            print("BroadcastProviderMessage IDs associated with BroadcastEvents:")
             if len(broadcast_provider_message_ids):
                 print("\n".join(broadcast_provider_message_ids))
             else:
@@ -123,26 +123,26 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=T
 
             if not dry_run:
                 if len(broadcast_provider_message_ids):
-                    print(">>> Deleting BroadcastProviderMessageNumber rows...")
+                    print("Deleting BroadcastProviderMessageNumber rows...")
                     db.session.query(BroadcastProviderMessageNumber).filter(
                         BroadcastProviderMessageNumber.broadcast_provider_message_id.in_(broadcast_provider_message_ids)
                     ).delete(synchronize_session=False)
                     print("...done")
 
-                    print(">>> Deleting BroadcastProviderMessage rows...")
+                    print("Deleting BroadcastProviderMessage rows...")
                     db.session.query(BroadcastProviderMessage).filter(
                         BroadcastProviderMessage.id.in_(broadcast_provider_message_ids)
                     ).delete(synchronize_session=False)
                     print("...done")
 
                 if len(broadcast_event_ids):
-                    print(">>> Deleting BroadcastEvent rows...")
+                    print("Deleting BroadcastEvent rows...")
                     db.session.query(BroadcastEvent).filter(BroadcastEvent.id.in_(broadcast_event_ids)).delete(
                         synchronize_session=False
                     )
                     print("...done")
 
-                print(">>> Deleting BroadcastMessage ...")
+                print("Deleting BroadcastMessage ...")
                 db.session.query(BroadcastMessage).filter_by(id=message_id).delete(synchronize_session=False)
                 print("...done")
 

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -98,7 +98,9 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
 
     for message in messages:
         try:
+            print(f"Removing message ID: {message.id}")
             broadcast_event_rows = db.session.query(BroadcastEvent.id).filter_by(broadcast_message_id=message.id).all()
+            print(broadcast_event_rows)
             broadcast_event_ids = [str(row[0]) for row in broadcast_event_rows]
 
             print(f"Events associated with message {message.id}: {broadcast_event_rows}")
@@ -112,6 +114,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
                 .filter(BroadcastProviderMessage.broadcast_event_id.in_(broadcast_event_ids))
                 .all()
             )
+            print(broadcast_provider_message_rows)
             broadcast_provider_message_ids = [str(row[0]) for row in broadcast_provider_message_rows]
 
             print(f"BroadcastProviderMessage rows associated with events: {broadcast_provider_message_ids}")

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 
-from config import config
+from flask import current_app
 from sqlalchemy import desc
 
 from app import db
@@ -90,8 +90,9 @@ def dao_get_all_broadcast_messages():
 def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     service_id = None
     if service is None:
-        service_name = config["broadcast_service"]["service_name"]
-        service_id = Service.query(Service.id).filter(Service.name == service_name).one()
+        # service_name = current_app.config["FUNCTIONAL_TESTS_BROADCAST_SERVICE_NAME"]
+        # service_id = Service.query(Service.id).filter(Service.name == service_name).one()
+        service_id = current_app.config["FUNCTIONAL_TESTS_BROADCAST_SERVICE_ID"]
     else:
         try:
             _ = uuid.UUID(service)

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -121,7 +121,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
 
     for message in messages:
         try:
-            broadcast_event_ids = session.query(BroadcastEvent.id).filter_by(id=message.id).all()
+            broadcast_event_ids = session.query(BroadcastEvent.id).filter_by(broadcast_message_id=message.id).all()
             print(f"Event IDs associated with message {message.id}: {broadcast_event_ids}")
             session.query(BroadcastProviderMessage).filter(
                 BroadcastProviderMessage.broadcast_event_id.in_(broadcast_event_ids)

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -94,7 +94,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=T
 
     message_ids = _get_broadcast_messages(days_older_than, service_id)
     print(f">>> Messages to purge, associated with service {service_id}:")
-    print("\n" + "\n".join(message_ids))
+    print("\n".join(message_ids))
 
     for message_id in message_ids:
         try:
@@ -103,7 +103,10 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=T
             broadcast_event_rows = db.session.query(BroadcastEvent.id).filter_by(broadcast_message_id=message_id).all()
             broadcast_event_ids = [str(row[0]) for row in broadcast_event_rows]
             print(f">>> BroadcastEvent IDs associated with messsage {message_id}:")
-            print("\n" + "\n".join(broadcast_event_ids))
+            if len(broadcast_event_ids):
+                print("\n".join(broadcast_event_ids))
+            else:
+                print("None")
 
             broadcast_provider_message_rows = (
                 db.session.query(BroadcastProviderMessage.id)
@@ -113,32 +116,38 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None, dry_run=T
             broadcast_provider_message_ids = [str(row[0]) for row in broadcast_provider_message_rows]
 
             print(">>> BroadcastProviderMessage IDs associated with BroadcastEvents:")
-            print("\n" + "\n".join(broadcast_provider_message_ids))
+            if len(broadcast_provider_message_ids):
+                print("\n".join(broadcast_provider_message_ids))
+            else:
+                print("None")
 
             if not dry_run:
-                print(">>> Deleting BroadcastProviderMessageNumber rows...")
-                db.session.query(BroadcastProviderMessageNumber).filter(
-                    BroadcastProviderMessageNumber.broadcast_provider_message_id.in_(broadcast_provider_message_ids)
-                ).delete(synchronize_session=False)
-                print("...done")
+                if len(broadcast_provider_message_ids):
+                    print(">>> Deleting BroadcastProviderMessageNumber rows...")
+                    db.session.query(BroadcastProviderMessageNumber).filter(
+                        BroadcastProviderMessageNumber.broadcast_provider_message_id.in_(broadcast_provider_message_ids)
+                    ).delete(synchronize_session=False)
+                    print("...done")
 
-                print(">>> Deleting BroadcastProviderMessage rows...")
-                db.session.query(BroadcastProviderMessage).filter(
-                    BroadcastProviderMessage.id.in_(broadcast_provider_message_ids)
-                ).delete(synchronize_session=False)
-                print("...done")
+                    print(">>> Deleting BroadcastProviderMessage rows...")
+                    db.session.query(BroadcastProviderMessage).filter(
+                        BroadcastProviderMessage.id.in_(broadcast_provider_message_ids)
+                    ).delete(synchronize_session=False)
+                    print("...done")
 
-                print(">>> Deleting BroadcastEvent rows...")
-                db.session.query(BroadcastEvent).filter(BroadcastEvent.id.in_(broadcast_event_ids)).delete(
-                    synchronize_session=False
-                )
-                print("...done")
+                if len(broadcast_event_ids):
+                    print(">>> Deleting BroadcastEvent rows...")
+                    db.session.query(BroadcastEvent).filter(BroadcastEvent.id.in_(broadcast_event_ids)).delete(
+                        synchronize_session=False
+                    )
+                    print("...done")
 
                 print(">>> Deleting BroadcastMessage ...")
                 db.session.query(BroadcastMessage).filter_by(id=message_id).delete(synchronize_session=False)
                 print("...done")
 
                 db.session.commit()
+
         except Exception as e:
             if not dry_run:
                 db.session.rollback()

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -121,7 +121,8 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
 
     for message in messages:
         try:
-            broadcast_event_ids = session.query(BroadcastEvent.id).filter_by(broadcast_message_id=message.id).all()
+            broadcast_event_rows = session.query(BroadcastEvent.id).filter_by(broadcast_message_id=message.id).all()
+            broadcast_event_ids = [str(row[0]) for row in broadcast_event_rows]
             print(f"Event IDs associated with message {message.id}: {broadcast_event_ids}")
             session.query(BroadcastProviderMessage).filter(
                 BroadcastProviderMessage.broadcast_event_id.in_(broadcast_event_ids)

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -86,7 +86,6 @@ def dao_get_all_broadcast_messages():
     )
 
 
-@autocommit
 def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     service_id = None
     session = db.session
@@ -121,7 +120,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     print(messages)
 
     for message in messages:
-        transaction = session.begin()
+        #  transaction = session.begin()
         try:
             bms = session.query(BroadcastMessage).filter_by(id=message.id)
             print(bms)
@@ -141,9 +140,9 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
             print(bes)
             session.query(BroadcastEvent).filter_by(broadcast_message_id=message.id).delete(synchronize_session=False)
 
-            transaction.commit()
+            session.commit()
         except Exception as e:
-            transaction.rollback()
+            session.rollback()
             raise e
 
 

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -89,20 +89,20 @@ def dao_get_all_broadcast_messages():
 @autocommit
 def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     service_id = None
+    session = db.session
     if service is None:
         service_id = current_app.config["FUNCTIONAL_TESTS_BROADCAST_SERVICE_ID"]
     else:
         try:
             _ = uuid.UUID(service)
-            if Service.query(Service.name).filter(Service.id == service).one():
+            if session.query(Service.name).filter(Service.id == service).one():
                 service_id = service
         except ValueError:
-            service_id = Service.query(Service.id).filter(Service.name == service).one()
+            service_id = session.query(Service.id).filter(Service.name == service).one()
 
     if service_id is None:
         raise "Unable to find service ID"
 
-    session = db.session
     messages = (
         session.query(
             BroadcastMessage.id,

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -100,7 +100,11 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
             broadcast_event_rows = db.session.query(BroadcastEvent.id).filter_by(broadcast_message_id=message.id).all()
             broadcast_event_ids = [str(row[0]) for row in broadcast_event_rows]
 
-            print(f"Event IDs associated with message {message.id}: {broadcast_event_ids}")
+            print(f"Events associated with message {message.id}: {broadcast_event_rows}")
+            print("-------------------------------------------------------------------------")
+            print([str(row[0]) for row in broadcast_event_rows])
+            print([str(row[0][0]) for row in broadcast_event_rows])
+            print("-------------------------------------------------------------------------")
 
             broadcast_provider_message_rows = (
                 db.session.query(BroadcastProviderMessage.id)

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -94,7 +94,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     else:
         try:
             _ = uuid.UUID(service)
-            if Service.query(Service.name).where(Service.id == service).one():
+            if Service.query(Service.name).filter(Service.id == service).one():
                 service_id = service
         except ValueError:
             service_id = Service.query(Service.id).filter(Service.name == service).one()

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -124,7 +124,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
             broadcast_event_ids = session.query(BroadcastEvent.id).filter_by(id=message.id).all()
             print(f"Event IDs associated with message {message.id}: {broadcast_event_ids}")
             session.query(BroadcastProviderMessage).filter(
-                BroadcastProviderMessage.c.broadcast_event_id.in_(broadcast_event_ids)
+                BroadcastProviderMessage.broadcast_event_id.in_(broadcast_event_ids)
             ).delete(synchronize_session=False)
 
             # broadcast_provider_messages = (
@@ -135,7 +135,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
             # print(broadcast_provider_messages)
             # broadcast_provider_messages.delete(synchronize_session=False)
 
-            session.query(BroadcastEvent).filter(BroadcastEvent.c.id.in_(broadcast_event_ids)).delete(
+            session.query(BroadcastEvent).filter(BroadcastEvent.id.in_(broadcast_event_ids)).delete(
                 synchronize_session=False
             )
 

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -90,13 +90,11 @@ def dao_get_all_broadcast_messages():
 def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
     service_id = None
     if service is None:
-        # service_name = current_app.config["FUNCTIONAL_TESTS_BROADCAST_SERVICE_NAME"]
-        # service_id = Service.query(Service.id).filter(Service.name == service_name).one()
         service_id = current_app.config["FUNCTIONAL_TESTS_BROADCAST_SERVICE_ID"]
     else:
         try:
             _ = uuid.UUID(service)
-            if db.session.exists(Service).where(Service.id == service).scalar():
+            if Service.query(Service.name).where(Service.id == service).one():
                 service_id = service
         except ValueError:
             service_id = Service.query(Service.id).filter(Service.name == service).one()

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -143,7 +143,7 @@ def dao_purge_old_broadcast_messages(days_older_than=30, service=None):
             # print(broadcast_events)
             # broadcast_events.delete(synchronize_session=False)
 
-            broadcast_messages = session.query(BroadcastMessage).filter(id=message.id)
+            broadcast_messages = session.query(BroadcastMessage).filter_by(id=message.id)
             broadcast_messages.delete(synchronize_session=False)
 
             session.commit()

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -39,6 +39,8 @@ networks:
 
 # To start postgres to run tests from local api directory,
 # use the following commands:
+# cd /eas/emergency-alerts-api && . /venv/eas-api/bin/activate
 # docker compose -f docker-compose-tests.yml up --force-recreate -d pg
-# cd /eas/emergency-alerts-api && . /venv/eas-api/bin/activate && make test
+# . ./environment.sh && make test
+# Optional:
 # docker compose -f docker-compose-tests.yml down

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 
 import pytest
@@ -651,3 +652,16 @@ def test_update_broadcast_message_status_rejects_approval_from_user_not_on_that_
 
     assert mock_task.called is False
     assert "cannot update broadcast" in response["message"]
+
+
+def test_purge_broadcast_messages(admin_request, sample_broadcast_service, mocker):
+    response = admin_request.get(
+        "broadcast_message.purge_broadcast_messages",
+        service_id=sample_broadcast_service.id,
+        older_than=100,
+        _expected_status=200,
+    )
+
+    print(response["message"])
+
+    assert re.match(r"Purged (\d+) BroadcastMessage items (.*)", response["message"])

--- a/tests/app/dao/test_broadcast_message_dao.py
+++ b/tests/app/dao/test_broadcast_message_dao.py
@@ -10,7 +10,11 @@ from app.dao.broadcast_message_dao import (
 from app.dao.broadcast_service_dao import (
     insert_or_update_service_broadcast_settings,
 )
-from app.models import BROADCAST_TYPE, BroadcastEventMessageType
+from app.models import (
+    BROADCAST_TYPE,
+    BroadcastEventMessageType,
+    BroadcastStatusType,
+)
 from tests.app.db import create_broadcast_event, create_broadcast_message
 from tests.app.db import (
     create_broadcast_provider_message as create_broadcast_provider_message_test,
@@ -151,19 +155,34 @@ def test_dao_purge_old_broadcast_messages(sample_broadcast_service):
 
     broadcast_messages = [
         create_broadcast_message(
-            t, created_at=datetime(2023, 10, 8, 12, 0, 0), starts_at=datetime.now(), status="pending-approval"
+            t,
+            created_at=datetime(2023, 10, 8, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.PENDING_APPROVAL,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2023, 12, 9, 12, 0, 0), starts_at=datetime.now(), status="pending-approval"
+            t,
+            created_at=datetime(2023, 12, 9, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.PENDING_APPROVAL,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 10, 12, 0, 0), starts_at=datetime.now(), status="pending-approval"
+            t,
+            created_at=datetime(2024, 1, 10, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.PENDING_APPROVAL,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 11, 15, 0, 0), starts_at=datetime.now(), status="pending-approval"
+            t,
+            created_at=datetime(2024, 1, 12, 15, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.PENDING_APPROVAL,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 12, 9, 0, 0), starts_at=datetime.now(), status="pending-approval"
+            t,
+            created_at=datetime(2024, 1, 13, 9, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.PENDING_APPROVAL,
         ),
     ]
 
@@ -173,7 +192,7 @@ def test_dao_purge_old_broadcast_messages(sample_broadcast_service):
     # purge all messages older than the two most recent
     older_than = (datetime.now() - datetime(2024, 1, 11)).days
 
-    messages_purged_count = dao_purge_old_broadcast_messages(older_than, str(sample_broadcast_service.id))
+    messages_purged_count = dao_purge_old_broadcast_messages(str(sample_broadcast_service.id), older_than)
     remaining_messages = dao_get_all_pre_broadcast_messages()
 
     assert messages_purged_count["msgs"] == test_message_count - len(remaining_messages)
@@ -198,19 +217,34 @@ def test_dao_purge_old_broadcast_messages_and_broadcast_events(sample_broadcast_
 
     broadcast_messages = [
         create_broadcast_message(
-            t, created_at=datetime(2023, 10, 8, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2023, 10, 8, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2023, 12, 9, 12, 0, 0), starts_at=datetime.now(), status="cancelled"
+            t,
+            created_at=datetime(2023, 12, 9, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.CANCELLED,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 10, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2024, 1, 10, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 11, 15, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2024, 1, 12, 15, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 12, 9, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2024, 1, 13, 9, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
     ]
 
@@ -235,7 +269,7 @@ def test_dao_purge_old_broadcast_messages_and_broadcast_events(sample_broadcast_
     # purge all messages older than the two most recent
     older_than = (datetime.now() - datetime(2024, 1, 11)).days
 
-    messages_purged_count = dao_purge_old_broadcast_messages(older_than, str(sample_broadcast_service.id))
+    messages_purged_count = dao_purge_old_broadcast_messages(str(sample_broadcast_service.id), older_than)
     remaining_messages = dao_get_all_broadcast_messages()
 
     assert messages_purged_count["msgs"] == test_message_count - len(remaining_messages)
@@ -255,22 +289,40 @@ def test_dao_purge_old_broadcastmessages_events_providermessages_and_providermes
 
     broadcast_messages = [
         create_broadcast_message(
-            t, created_at=datetime(2023, 10, 8, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2023, 10, 8, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2023, 10, 15, 12, 0, 0), starts_at=datetime.now(), status="cancelled"
+            t,
+            created_at=datetime(2023, 10, 15, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.CANCELLED,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2023, 12, 9, 12, 0, 0), starts_at=datetime.now(), status="cancelled"
+            t,
+            created_at=datetime(2023, 12, 9, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.CANCELLED,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 10, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2024, 1, 10, 12, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 11, 15, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2024, 1, 12, 15, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
         create_broadcast_message(
-            t, created_at=datetime(2024, 1, 12, 9, 0, 0), starts_at=datetime.now(), status="broadcasting"
+            t,
+            created_at=datetime(2024, 1, 13, 9, 0, 0),
+            starts_at=datetime.now(),
+            status=BroadcastStatusType.BROADCASTING,
         ),
     ]
 
@@ -299,7 +351,7 @@ def test_dao_purge_old_broadcastmessages_events_providermessages_and_providermes
     # purge all messages older than the two most recent
     older_than = (datetime.now() - datetime(2024, 1, 11)).days
 
-    purged_count = dao_purge_old_broadcast_messages(older_than, str(sample_broadcast_service.id))
+    purged_count = dao_purge_old_broadcast_messages(str(sample_broadcast_service.id), older_than)
     remaining_messages = dao_get_all_broadcast_messages()
 
     assert purged_count["msgs"] == test_message_count - len(remaining_messages)

--- a/tests/app/dao/test_broadcast_message_dao.py
+++ b/tests/app/dao/test_broadcast_message_dao.py
@@ -1,20 +1,21 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from app.dao.broadcast_message_dao import (
     create_broadcast_provider_message,
     dao_get_all_broadcast_messages,
+    dao_get_all_pre_broadcast_messages,
+    dao_purge_old_broadcast_messages,
     get_earlier_events_for_broadcast_event,
 )
 from app.dao.broadcast_service_dao import (
     insert_or_update_service_broadcast_settings,
 )
 from app.models import BROADCAST_TYPE, BroadcastEventMessageType
+from tests.app.db import create_broadcast_event, create_broadcast_message
 from tests.app.db import (
-    create_broadcast_event,
-    create_broadcast_message,
-    create_service,
-    create_template,
+    create_broadcast_provider_message as create_broadcast_provider_message_test,
 )
+from tests.app.db import create_service, create_template
 
 
 def test_get_earlier_events_for_broadcast_event(sample_service):
@@ -141,3 +142,173 @@ def test_dao_get_all_broadcast_messages(sample_broadcast_service):
             None,
         ),
     ]
+
+
+def test_dao_purge_old_broadcast_messages(sample_broadcast_service):
+    t = create_template(sample_broadcast_service, BROADCAST_TYPE)
+
+    baseline_message_count = len(dao_get_all_pre_broadcast_messages())
+
+    broadcast_messages = [
+        create_broadcast_message(
+            t, created_at=datetime(2023, 10, 8, 12, 0, 0), starts_at=datetime.now(), status="pending-approval"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2023, 12, 9, 12, 0, 0), starts_at=datetime.now(), status="pending-approval"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 10, 12, 0, 0), starts_at=datetime.now(), status="pending-approval"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 11, 15, 0, 0), starts_at=datetime.now(), status="pending-approval"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 12, 9, 0, 0), starts_at=datetime.now(), status="pending-approval"
+        ),
+    ]
+
+    test_message_count = len(dao_get_all_pre_broadcast_messages())
+    assert test_message_count == baseline_message_count + 5
+
+    # purge all messages older than the two most recent
+    older_than = (datetime.now() - datetime(2024, 1, 11)).days
+
+    messages_purged_count = dao_purge_old_broadcast_messages(older_than, str(sample_broadcast_service.id))
+    remaining_messages = dao_get_all_pre_broadcast_messages()
+
+    assert messages_purged_count["msgs"] == test_message_count - len(remaining_messages)
+    assert messages_purged_count["events"] == 0  # no events yet for pre-broadcast messages
+
+    # expect that the first 3 of our test messages have been purged
+    expected_remaining_messages_ids = [str(broadcast_messages[3].id), str(broadcast_messages[4].id)]
+
+    # To get ID, we need to cast the first element of the row tuple to a string
+    # [
+    #     (UUID('d8946a4e-f7a2-4c39-9187-e15f328590d3'), datetime.datetime(2024, 1, 12, 9, 0), ... ),
+    #     (UUID('03cf5d86-7da2-4300-b3cc-ed92612e8cfd'), datetime.datetime(2024, 1, 11, 15, 0), ...)
+    # ]
+    assert str(remaining_messages[0][0]) in expected_remaining_messages_ids
+    assert str(remaining_messages[1][0]) in expected_remaining_messages_ids
+
+
+def test_dao_purge_old_broadcast_messages_and_broadcast_events(sample_broadcast_service):
+    t = create_template(sample_broadcast_service, BROADCAST_TYPE)
+
+    baseline_message_count = len(dao_get_all_broadcast_messages())
+
+    broadcast_messages = [
+        create_broadcast_message(
+            t, created_at=datetime(2023, 10, 8, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2023, 12, 9, 12, 0, 0), starts_at=datetime.now(), status="cancelled"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 10, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 11, 15, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 12, 9, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+    ]
+
+    for bm in broadcast_messages:
+        create_broadcast_event(
+            bm,
+            sent_at=bm.starts_at + timedelta(minutes=1),
+            message_type=BroadcastEventMessageType.ALERT,
+            transmitted_content={"body": "Initial content"},
+        )
+        if bm.status == "cancelled":
+            create_broadcast_event(
+                bm,
+                sent_at=bm.starts_at + timedelta(minutes=2),
+                message_type=BroadcastEventMessageType.CANCEL,
+                transmitted_finishes_at=bm.starts_at + timedelta(minutes=2),
+            )
+
+    test_message_count = len(dao_get_all_broadcast_messages())
+    assert test_message_count == baseline_message_count + 5
+
+    # purge all messages older than the two most recent
+    older_than = (datetime.now() - datetime(2024, 1, 11)).days
+
+    messages_purged_count = dao_purge_old_broadcast_messages(older_than, str(sample_broadcast_service.id))
+    remaining_messages = dao_get_all_broadcast_messages()
+
+    assert messages_purged_count["msgs"] == test_message_count - len(remaining_messages)
+    assert messages_purged_count["events"] == 4
+
+    # expect that the first 3 of our test messages have been purged
+    expected_remaining_messages_ids = [str(broadcast_messages[3].id), str(broadcast_messages[4].id)]
+
+    assert str(remaining_messages[0][0]) in expected_remaining_messages_ids
+    assert str(remaining_messages[1][0]) in expected_remaining_messages_ids
+
+
+def test_dao_purge_old_broadcastmessages_events_providermessages_and_providermessagenumbers(sample_broadcast_service):
+    t = create_template(sample_broadcast_service, BROADCAST_TYPE)
+
+    baseline_message_count = len(dao_get_all_broadcast_messages())
+
+    broadcast_messages = [
+        create_broadcast_message(
+            t, created_at=datetime(2023, 10, 8, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2023, 10, 15, 12, 0, 0), starts_at=datetime.now(), status="cancelled"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2023, 12, 9, 12, 0, 0), starts_at=datetime.now(), status="cancelled"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 10, 12, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 11, 15, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+        create_broadcast_message(
+            t, created_at=datetime(2024, 1, 12, 9, 0, 0), starts_at=datetime.now(), status="broadcasting"
+        ),
+    ]
+
+    for bm in broadcast_messages:
+        be1 = create_broadcast_event(
+            bm,
+            sent_at=bm.starts_at + timedelta(minutes=1),
+            message_type=BroadcastEventMessageType.ALERT,
+            transmitted_content={"body": "Initial content"},
+        )
+        create_broadcast_provider_message_test(be1, "ee", status="returned-ack")
+        create_broadcast_provider_message_test(be1, "vodafone", status="returned-ack")
+        if bm.status == "cancelled":
+            be2 = create_broadcast_event(
+                bm,
+                sent_at=bm.starts_at + timedelta(minutes=2),
+                message_type=BroadcastEventMessageType.CANCEL,
+                transmitted_finishes_at=bm.starts_at + timedelta(minutes=2),
+            )
+            create_broadcast_provider_message_test(be2, "ee", status="returned-ack")
+            create_broadcast_provider_message_test(be2, "vodafone", status="returned-ack")
+
+    test_message_count = len(dao_get_all_broadcast_messages())
+    assert test_message_count == baseline_message_count + 6
+
+    # purge all messages older than the two most recent
+    older_than = (datetime.now() - datetime(2024, 1, 11)).days
+
+    purged_count = dao_purge_old_broadcast_messages(older_than, str(sample_broadcast_service.id))
+    remaining_messages = dao_get_all_broadcast_messages()
+
+    assert purged_count["msgs"] == test_message_count - len(remaining_messages)
+    assert purged_count["events"] == 6
+    assert purged_count["provider_msgs"] == 12
+    assert purged_count["msg_numbers"] == 6
+
+    # expect that the first 3 of our test messages have been purged
+    expected_remaining_messages_ids = [str(broadcast_messages[4].id), str(broadcast_messages[5].id)]
+
+    assert str(remaining_messages[0][0]) in expected_remaining_messages_ids
+    assert str(remaining_messages[1][0]) in expected_remaining_messages_ids

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -1160,6 +1160,7 @@ def create_broadcast_message(
     areas=None,
     stubbed=False,
     cap_event=None,
+    created_at=None,  # only used for testing
 ):
     if template:
         service = template.service
@@ -1188,6 +1189,7 @@ def create_broadcast_message(
         content=content,
         stubbed=stubbed,
         cap_event=cap_event,
+        created_at=created_at,
     )
     db.session.add(broadcast_message)
     db.session.commit()


### PR DESCRIPTION
This PR adds a method for purging old alerts from the database:
- At this time, this is only intended for use in the preview environment, due to the large number of alerts generated daily by the functional tests
- The new database method has supporting unit tests, which verify the purging of BroadcastMessage, BroadcastEvent, BroadcastProviderMessage and BroadcastProviderMessageNumber items
- The new method can be reached via an api call or via a command
- The purge method requires a service ID as well as a value specifying the minimum age of messages to be purged
- A 'dry-run' parameter can be used in the terminal to display the items that will be purged, without removing them from the database.