### PR TITLE
EAS-1887 Smoke test partitioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,7 @@ run-celery: ## Run celery
 		--pidfile=/tmp/celery.pid \
 		--prefetch-multiplier=1 \
 		--loglevel=WARNING \
-		--concurrency=1 \
-		--autoscale=1,1 \
+		--autoscale=8,1 \
 		--hostname=0.0.0.0
 
 .PHONY: run-celery-with-docker

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ run-celery: ## Run celery
 		--prefetch-multiplier=1 \
 		--loglevel=WARNING \
 		--concurrency=1 \
-		--autoscale=1,1
+		--autoscale=1,1 \
+		--hostname=0.0.0.0
 
 .PHONY: run-celery-with-docker
 run-celery-with-docker: ## Run celery in Docker container (useful if you can't install pycurl locally)

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ run-celery: ## Run celery
 		--prefetch-multiplier=1 \
 		--loglevel=WARNING \
 		--concurrency=1 \
-		--autoscale=1,1 \
-		--hostname=0.0.0.0
+		--autoscale=1,1
 
 .PHONY: run-celery-with-docker
 run-celery-with-docker: ## Run celery in Docker container (useful if you can't install pycurl locally)

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -121,7 +121,7 @@ def send_broadcast_event(broadcast_event_id):
     name="send-broadcast-provider-message",
     autoretry_for=(CBCProxyRetryableException,),
     retry_backoff=3,
-    retry_jitter=False,
+    retry_jitter=True,
     max_retries=5,
 )
 def send_broadcast_provider_message(self, broadcast_event_id, provider):

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -143,6 +143,7 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
 
     # the broadcast_provider_message may already exist if we retried previously
     broadcast_provider_message = broadcast_event.get_provider_message(provider)
+    sqs_retry = broadcast_provider_message is not None
     if broadcast_provider_message is None:
         broadcast_provider_message = create_broadcast_provider_message(broadcast_event, provider)
 
@@ -156,6 +157,7 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
             "broadcast_provider_message_id": broadcast_provider_message.id,
             "broadcast_event_id": broadcast_event_id,
             "message_type": broadcast_event.message_type,
+            "sqs_retry": sqs_retry,
             "python_module": __name__,
         },
     )

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -120,7 +120,8 @@ def send_broadcast_event(broadcast_event_id):
     bind=True,
     name="send-broadcast-provider-message",
     autoretry_for=(CBCProxyRetryableException,),
-    retry_backoff=True,
+    retry_backoff=3,
+    retry_jitter=False,
     max_retries=5,
 )
 def send_broadcast_provider_message(self, broadcast_event_id, provider):

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -143,7 +143,7 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
 
     # the broadcast_provider_message may already exist if we retried previously
     broadcast_provider_message = broadcast_event.get_provider_message(provider)
-    sqs_retry = broadcast_provider_message is not None
+    is_retry = broadcast_provider_message is not None
     if broadcast_provider_message is None:
         broadcast_provider_message = create_broadcast_provider_message(broadcast_event, provider)
 
@@ -157,7 +157,7 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
             "broadcast_provider_message_id": broadcast_provider_message.id,
             "broadcast_event_id": broadcast_event_id,
             "message_type": broadcast_event.message_type,
-            "sqs_retry": sqs_retry,
+            "is_retry": is_retry,
             "python_module": __name__,
         },
     )

--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -136,6 +136,8 @@ def validate_functional_test_account_emails():
         save_model_user(user1, validated_email_access=True)
         user2 = get_user_by_email("notify-tests-preview+local-broadcast2@digital.cabinet-office.gov.uk")
         save_model_user(user2, validated_email_access=True)
+        user3 = get_user_by_email("notify-tests-preview+local-broadcast3@digital.cabinet-office.gov.uk")
+        save_model_user(user3, validated_email_access=True)
     except SQLAlchemyError as e:
         current_app.logger.exception(e)
     else:

--- a/app/config.py
+++ b/app/config.py
@@ -168,7 +168,7 @@ class Config(object):
             # "visibility_timeout": 310,    # Configured in Terraform
             "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
             "is_secure": True,
-            "task_acks_late": False,
+            "task_acks_late": True,
         },
         "timezone": "UTC",
         "imports": [

--- a/app/config.py
+++ b/app/config.py
@@ -220,7 +220,7 @@ class Config(object):
             },
             "validate-functional-test-account-emails": {
                 "task": "validate-functional-test-account-emails",
-                "schedule": crontab(day_of_month="1"),
+                "schedule": crontab(day_of_month="5"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
         },

--- a/app/config.py
+++ b/app/config.py
@@ -168,7 +168,7 @@ class Config(object):
             # "visibility_timeout": 310,    # Configured in Terraform
             "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
             "is_secure": True,
-            "task_acks_late": True,
+            "task_acks_late": False,
         },
         "timezone": "UTC",
         "imports": [

--- a/app/config.py
+++ b/app/config.py
@@ -220,7 +220,7 @@ class Config(object):
             },
             "validate-functional-test-account-emails": {
                 "task": "validate-functional-test-account-emails",
-                "schedule": crontab(day_of_month="5"),
+                "schedule": crontab(day_of_month="1"),
                 "options": {"queue": QueueNames.PERIODIC},
             },
         },


### PR DESCRIPTION
This PR adds the account used by the "platform-admin-flow" integration (smoke) tests to the periodic user refresh job.

This will prevent the test failing due to the email validity check (The one which throws up the splash screen that says "For security, we need to check if you still have access to your email address.").