### PR TITLE
EAS-2243 Add OPTIONS method

### DIFF
--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -2,7 +2,7 @@ from itertools import chain
 
 from emergency_alerts_utils.polygons import Polygons
 from emergency_alerts_utils.template import BroadcastMessageTemplate
-from flask import current_app, jsonify, request
+from flask import current_app, jsonify, make_response, request
 from sqlalchemy.orm.exc import MultipleResultsFound
 
 from app import api_user, authenticated_service, redis_store
@@ -98,6 +98,15 @@ def create_broadcast():
         )
 
         return jsonify(broadcast_message.serialize()), 201
+
+
+@v2_broadcast_blueprint.route("", methods=["OPTIONS"])
+def return_status():
+    response = make_response()
+    response.headers["Allow"] = "OPTIONS, POST"
+    response.headers["Content-Type"] = "application/json"
+    response.status_code = 200
+    return response
 
 
 def _cancel_or_reject_broadcast(references_to_original_broadcast, service_id):

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -481,4 +481,3 @@ def test_request_for_status_returns_allowed_methods(client, sample_broadcast_ser
     assert "OPTIONS" in response.headers["Allow"]
     assert "POST" in response.headers["Allow"]
     assert response.headers["Content-Length"] == "0"
-    assert False

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -468,3 +468,17 @@ def test_invalid_areas_returns_400(client, sample_broadcast_service):
         ],
         "status_code": 400,
     }
+
+
+def test_request_for_status_returns_allowed_methods(client, sample_broadcast_service):
+    auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
+    response = client.options(
+        path="/v2/broadcast",
+        headers=[auth_header],
+    )
+
+    assert response.status_code == 200
+    assert "OPTIONS" in response.headers["Allow"]
+    assert "POST" in response.headers["Allow"]
+    assert response.headers["Content-Length"] == "0"
+    assert False


### PR DESCRIPTION
The "is the api alive" question can be answered by querying the endpoint v2/broadcast with the "OPTIONS" method.

This endpoint handler returns an empty response, with a header showing which methods are allowed on the url, i.e. "OPTIONS, POST".