### PR TITLE
EAS-2322 Remove randomness from retry backoff

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -121,7 +121,7 @@ def send_broadcast_event(broadcast_event_id):
     name="send-broadcast-provider-message",
     autoretry_for=(CBCProxyRetryableException,),
     retry_backoff=3,
-    retry_jitter=True,
+    retry_jitter=False,
     max_retries=5,
 )
 def send_broadcast_provider_message(self, broadcast_event_id, provider):


### PR DESCRIPTION
With "retry_jitter: True" the retry delay may be zero - empirical observation suggests that the application (celery?) does not handle this reliably and some retries can be lost.