### PR TITLE
EAS-1055 Pass broadcast-event-id to Celery task

### DIFF
--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -108,7 +108,11 @@ def check_event_makes_sense_in_sequence(broadcast_event, provider):
 def send_broadcast_event(broadcast_event_id):
     broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
-    notify_celery.send_task(name=TaskNames.PUBLISH_GOVUK_ALERTS, queue=QueueNames.GOVUK_ALERTS)
+    notify_celery.send_task(
+        name=TaskNames.PUBLISH_GOVUK_ALERTS,
+        queue=QueueNames.GOVUK_ALERTS,
+        kwargs={"broadcast_event_id": broadcast_event_id},
+    )
 
     for provider in broadcast_event.service.get_available_broadcast_providers():
         send_broadcast_provider_message.apply_async(

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -71,7 +71,9 @@ def test_send_broadcast_event_calls_publish_govuk_alerts_task(
     with set_config(notify_api, "ENABLED_CBCS", ["ee", "vodafone"]):
         send_broadcast_event(event.id)
 
-    mock.assert_called_once_with(name=TaskNames.PUBLISH_GOVUK_ALERTS, queue=QueueNames.GOVUK_ALERTS)
+    mock.assert_called_once_with(
+        name=TaskNames.PUBLISH_GOVUK_ALERTS, queue=QueueNames.GOVUK_ALERTS, kwargs={"broadcast_event_id": event.id}
+    )
 
 
 def test_send_broadcast_event_only_sends_to_one_provider_if_set_on_service(


### PR DESCRIPTION
Pass broadcast-event-id to Celery task so that the logs can show which alert triggered the re-render of HTML and upload to S3