### PR TITLE
EAS-2592: API: Use MANUAL_PIPELINE_BRANCH if present 

### DIFF
--- a/.codepipeline/buildspec-api-build.yml
+++ b/.codepipeline/buildspec-api-build.yml
@@ -4,7 +4,10 @@ phases:
   pre_build:
     commands:
       - |
-        if [ -n "$COMMIT_ID" ]; then
+        if [ -n "$MANUAL_PIPELINE_BRANCH" ]; then
+          echo Manual pipeline branch provided, checking out branch $MANUAL_PIPELINE_BRANCH
+          git checkout $MANUAL_PIPELINE_BRANCH
+        elif [ -n "$COMMIT_ID" ]; then
           echo Checking out to api_${ENVIRONMENT}_latest tag...
           git checkout tags/api_${ENVIRONMENT}_latest
         fi

--- a/.codepipeline/buildspec-celery-build.yml
+++ b/.codepipeline/buildspec-celery-build.yml
@@ -4,7 +4,10 @@ phases:
   pre_build:
     commands:
       - |
-        if [ -n "$COMMIT_ID" ]; then
+        if [ -n "$MANUAL_PIPELINE_BRANCH" ]; then
+          echo Manual pipeline branch provided, checking out branch $MANUAL_PIPELINE_BRANCH
+          git checkout $MANUAL_PIPELINE_BRANCH
+        elif [ -n "$COMMIT_ID" ]; then
           echo Checking out to celery_${ENVIRONMENT}_latest tag...
           git checkout tags/celery_${ENVIRONMENT}_latest
         fi

--- a/.codepipeline/buildspec-celery-deploy.yml
+++ b/.codepipeline/buildspec-celery-deploy.yml
@@ -4,7 +4,10 @@ phases:
   pre_build:
     commands:
       - |
-        if [ -n "$COMMIT_ID" ]; then
+        if [ -n "$MANUAL_PIPELINE_BRANCH" ]; then
+          echo Manual pipeline branch provided, checking out branch $MANUAL_PIPELINE_BRANCH
+          git checkout $MANUAL_PIPELINE_BRANCH
+        elif [ -n "$COMMIT_ID" ]; then
           echo Checking out to celery_${ENVIRONMENT}_latest tag...
           git checkout tags/celery_${ENVIRONMENT}_latest
         fi


### PR DESCRIPTION
In combination with https://github.com/alphagov/emergency-alerts-infra/pull/1263 this lets developers provide a feature branch to construct their builds from.

The idea is that MANUAL_PIPELINE_BRANCH will only be present if configured, so existing workflows should remain as they are, both for the legacy development technique and later environments.