### PR TITLE
EAS-2569: API: Fix AdminAction created_by being the server's start time

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -786,7 +786,7 @@ class AdminAction(db.Model):
 
     created_by_id = db.Column(UUID(as_uuid=True), db.ForeignKey("users.id"), index=True, nullable=False)
     created_by = db.relationship("User", foreign_keys=[created_by_id])
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.now(datetime.timezone.utc))
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.datetime.now(datetime.timezone.utc))
 
     status = db.Column(db.Enum(*ADMIN_STATUS_LIST, name="admin_action_status_types"), nullable=False)
 


### PR DESCRIPTION
By avoiding the deprecated `utcnow` I introduced a rather embarassing bug - the column default was evaluated when the server started and thus meant `created_at` would always be a bit meaningless.

The rest of this file _does_ use `utcnow` but I thought it's best not to clutter too much by changing it throughout.