### PR TITLE
Adds deletion of user permissions to purge route for functional tests

### DIFF
--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -11,7 +11,7 @@ from app.dao.dao_utils import autocommit
 from app.dao.permissions_dao import permission_dao
 from app.dao.service_user_dao import dao_get_service_users_by_user_id
 from app.errors import InvalidRequest
-from app.models import EMAIL_AUTH_TYPE, User, VerifyCode
+from app.models import EMAIL_AUTH_TYPE, Permission, User, VerifyCode
 from app.utils import escape_special_characters, get_archived_db_column_value
 
 
@@ -96,6 +96,11 @@ def delete_model_user(user):
 
 def delete_user_verify_codes(user):
     VerifyCode.query.filter_by(user=user).delete()
+    db.session.commit()
+
+
+def delete_permissions_for_user(user):
+    Permission.query.filter_by(user=user).delete()
     db.session.commit()
 
 

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -29,6 +29,7 @@ from app.dao.services_dao import (
 )
 from app.dao.users_dao import (
     delete_model_user,
+    delete_permissions_for_user,
     delete_user_verify_codes,
     get_user_by_id,
     get_users_by_partial_email,
@@ -327,6 +328,7 @@ def purge_users_created_by_tests():
         users = get_users_by_partial_email("emergency-alerts-fake-")
         for user in users:
             delete_user_verify_codes(user=user)
+            delete_permissions_for_user(user=user)
             delete_model_user(user=user)
     except Exception as e:
         return jsonify(result="error", message=f"Unable to purge users created by functional tests: {e}"), 500


### PR DESCRIPTION
This PR adds a function to the purge route that the functional tests call to clean up the users that have been created with each. The function deletes all of the permissions associated with the user that is to be deleted, to avoid the foreign key constraint error.