### PR TITLE
EAS-2569: API: Add endpoint to purge test admin actions

### DIFF
--- a/app/dao/admin_action_dao.py
+++ b/app/dao/admin_action_dao.py
@@ -1,5 +1,6 @@
 from emergency_alerts_utils.admin_action import ADMIN_STATUS_PENDING
 
+from app.dao.dao_utils import autocommit
 from app.models import AdminAction
 
 
@@ -15,6 +16,7 @@ def dao_get_all_admin_actions_by_user_id(user_id) -> list[AdminAction]:
     return AdminAction.query.filter_by(created_by_id=user_id).all()
 
 
+@autocommit
 def dao_delete_admin_action_by_id(action_id):
     """Delete an admin action - not just reject it (for tests)"""
-    return AdminAction.query.filter_by(id=action_id).delete()
+    return AdminAction.query.filter(AdminAction.id == action_id).delete()

--- a/app/dao/admin_action_dao.py
+++ b/app/dao/admin_action_dao.py
@@ -9,3 +9,12 @@ def dao_get_pending_admin_actions() -> list[AdminAction]:
 
 def dao_get_admin_action_by_id(action_id: str) -> AdminAction:
     return AdminAction.query.filter(AdminAction.id == action_id).one()
+
+
+def dao_get_all_admin_actions_by_user_id(user_id) -> list[AdminAction]:
+    return AdminAction.query.filter_by(created_by_id=user_id).all()
+
+
+def dao_delete_admin_action_by_id(action_id):
+    """Delete an admin action - not just reject it (for tests)"""
+    return AdminAction.query.filter_by(id=action_id).delete()


### PR DESCRIPTION
As title, for upcoming functional testing it'll be nice to wipe out all of admin actions it implicitly creates as it does for other entities (services, etc).