### PR TITLE
Ensure API tests container syncs to system time and timezone

### DIFF
--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -22,6 +22,8 @@ services:
       USER: $USER
     volumes:
       - ./postgres:/docker-entrypoint-initdb.d:ro
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
     networks:
       - test-network
     ports:


### PR DESCRIPTION
Using the fix created for another container here https://github.com/alphagov/emergency-alerts-tooling/pull/47