### PR TITLE
EAS-2626 Remove deprecated code and fix tests

### DIFF
--- a/app/dao/broadcast_service_dao.py
+++ b/app/dao/broadcast_service_dao.py
@@ -85,11 +85,9 @@ def insert_or_update_service_broadcast_settings(service, channel):
         settings = ServiceBroadcastSettings()
         settings.service = service
         settings.channel = channel
-        settings.provider = "deprecated"
         db.session.add(settings)
     else:
         service.service_broadcast_settings.channel = channel
-        service.service_broadcast_settings.provider = "deprecated"
         db.session.add(service.service_broadcast_settings)
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1198,7 +1198,6 @@ class ServiceBroadcastSettings(db.Model):
     service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), primary_key=True, nullable=False)
     service = db.relationship(Service, backref=db.backref("service_broadcast_settings", uselist=False))
     channel = db.Column(db.String(255), db.ForeignKey("broadcast_channel_types.name"), nullable=False)
-    provider = db.Column(db.String, db.ForeignKey("broadcast_provider_types.name"), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
 
@@ -1227,28 +1226,6 @@ class BroadcastProviderTypes(db.Model):
     __tablename__ = "broadcast_provider_types"
 
     name = db.Column(db.String(255), primary_key=True)
-
-
-class ServiceBroadcastProviderRestriction(db.Model):
-    """
-    TODO: Drop this table as no longer used
-
-    Most services don't send broadcasts. Of those that do, most send to all broadcast providers.
-    However, some services don't send to all providers. These services are test services that we or the providers
-    themselves use.
-
-    This table links those services. There should only be one row per service in this table, and this is enforced by
-    the service_id being a primary key.
-    """
-
-    __tablename__ = "service_broadcast_provider_restriction"
-
-    service_id = db.Column(UUID(as_uuid=True), db.ForeignKey("services.id"), primary_key=True, nullable=False)
-    service = db.relationship(Service, backref=db.backref("service_broadcast_provider_restriction", uselist=False))
-
-    provider = db.Column(db.String, nullable=False)
-
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
 
 
 class WebauthnCredential(db.Model):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -219,7 +219,6 @@ class ServiceSchema(BaseSchema, UUIDsAsStringsMixin):
             "broadcast_messages",
             "crown",
             "service_broadcast_settings",
-            "service_broadcast_provider_restriction",
             "templates",
             "updated_at",
             "users",

--- a/migrations/versions/0413_remove_old_service_code.py
+++ b/migrations/versions/0413_remove_old_service_code.py
@@ -1,0 +1,29 @@
+"""
+
+Revision ID: 0413_remove_old_service_code
+Revises: 0411_broadcast_message_history
+Create Date: 2025-03-24 11:16:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0413_remove_old_service_code"
+down_revision = "0412_service_providers"
+
+
+def upgrade():
+    op.drop_table("service_broadcast_provider_restriction")
+    op.drop_column("service_broadcast_settings", "provider")
+    op.execute(
+        """
+        DELETE FROM broadcast_provider_types
+        WHERE name IN ('all', 'deprecated')
+        """
+    )
+
+
+def downgrade():
+    pass

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -159,10 +159,12 @@ def test_get_service_by_id(admin_request, sample_service):
 @pytest.mark.parametrize(
     "broadcast_channel,allowed_broadcast_provider",
     (
-        ("operator", ["all"]),
-        ("test", ["all"]),
-        ("severe", ["all"]),
-        ("government", ["all"]),
+        ("operator", ["ee", "o2", "three", "vodafone"]),
+        ("test", ["ee", "o2", "three", "vodafone"]),
+        ("severe", ["ee", "o2", "three", "vodafone"]),
+        ("government", ["ee", "o2", "three", "vodafone"]),
+        ("severe", ["ee", "o2", "three"]),
+        ("government", ["three", "vodafone"]),
         ("operator", ["o2"]),
         ("test", ["ee"]),
         ("severe", ["three"]),
@@ -1190,7 +1192,7 @@ def test_set_as_broadcast_service_sets_broadcast_channel(
     data = {
         "broadcast_channel": channel,
         "service_mode": "live",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     result = admin_request.post(
@@ -1213,7 +1215,7 @@ def test_set_as_broadcast_service_updates_channel_for_broadcast_service(admin_re
     data = {
         "broadcast_channel": "test",
         "service_mode": "training",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     result = admin_request.post(
@@ -1279,7 +1281,7 @@ def test_set_as_broadcast_service_gives_broadcast_permission_and_removes_other_c
     data = {
         "broadcast_channel": "severe",
         "service_mode": "training",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     result = admin_request.post(
@@ -1313,7 +1315,7 @@ def test_set_as_broadcast_service_maintains_broadcast_permission_for_existing_br
     data = {
         "broadcast_channel": "severe",
         "service_mode": "live",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     result = admin_request.post(
@@ -1335,7 +1337,7 @@ def test_set_as_broadcast_service_sets_service_org_to_broadcast_org(
     data = {
         "broadcast_channel": "severe",
         "service_mode": "training",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
     result = admin_request.post(
         "service.set_as_broadcast_service",
@@ -1354,7 +1356,7 @@ def test_set_as_broadcast_service_does_not_error_if_run_on_a_service_that_is_alr
     data = {
         "broadcast_channel": "severe",
         "service_mode": "live",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
     for _ in range(2):
         admin_request.post(
@@ -1376,7 +1378,7 @@ def test_set_as_broadcast_service_sets_service_to_live_mode(
     data = {
         "broadcast_channel": "severe",
         "service_mode": "live",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     result = admin_request.post(
@@ -1401,7 +1403,7 @@ def test_set_as_broadcast_service_doesnt_override_existing_go_live_at(
     data = {
         "broadcast_channel": "severe",
         "service_mode": "live",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     result = admin_request.post(
@@ -1427,7 +1429,7 @@ def test_set_as_broadcast_service_sets_service_to_training_mode(
     data = {
         "broadcast_channel": "severe",
         "service_mode": "training",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     result = admin_request.post(
@@ -1461,7 +1463,7 @@ def test_set_as_broadcast_service_rejects_unknown_service_mode(
 def test_set_as_broadcast_service_rejects_if_no_service_mode(admin_request, sample_service, broadcast_organisation):
     data = {
         "broadcast_channel": "severe",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     admin_request.post(
@@ -1473,7 +1475,7 @@ def test_set_as_broadcast_service_rejects_if_no_service_mode(admin_request, samp
 
 
 @pytest.mark.parametrize(
-    "provider", [["all"], ["ee"], ["vodafone"], ["o2"], ["three", "vodafone"], ["ee", "o2", "three", "vodafone"]]
+    "provider", [["ee"], ["vodafone"], ["o2"], ["three", "vodafone"], ["ee", "o2", "three", "vodafone"]]
 )
 def test_set_as_broadcast_service_sets_mobile_provider_restriction(
     admin_request, sample_service, broadcast_organisation, provider
@@ -1496,7 +1498,7 @@ def test_set_as_broadcast_service_sets_mobile_provider_restriction(
         assert records[n].provider == provider[n]
 
 
-@pytest.mark.parametrize("provider", [["all"], ["vodafone"]])
+@pytest.mark.parametrize("provider", [["ee", "o2", "three", "vodafone"], ["vodafone"]])
 def test_set_as_broadcast_service_updates_mobile_provider_restriction(
     admin_request, notify_db_session, sample_broadcast_service, provider
 ):
@@ -1515,7 +1517,7 @@ def test_set_as_broadcast_service_updates_mobile_provider_restriction(
     assert result["data"]["allowed_broadcast_provider"] == provider
 
     records = ServiceBroadcastProviders.query.filter_by(service_id=sample_broadcast_service.id).all()
-    assert len(records) == 1
+    assert len(records) == len(provider)
     assert records[0].service_id == sample_broadcast_service.id
     assert records[0].provider == provider[0]
 
@@ -1555,7 +1557,7 @@ def test_set_as_broadcast_service_updates_services_history(admin_request, sample
     data = {
         "broadcast_channel": "test",
         "service_mode": "live",
-        "provider_restriction": ["all"],
+        "provider_restriction": ["ee", "o2", "three", "vodafone"],
     }
 
     admin_request.post(
@@ -1669,7 +1671,7 @@ def test_set_as_broadcast_service_revokes_api_keys(
         _data={
             "broadcast_channel": "government",
             "service_mode": "live",
-            "provider_restriction": ["all"],
+            "provider_restriction": ["ee", "o2", "three", "vodafone"],
         },
     )
 


### PR DESCRIPTION
Remove db objects and ORM code related to the old way of linking services to target MNOs.