### PR TITLE
Add PR checks even when a PR is in a drafted state

### DIFF
--- a/.github/workflows/on-pr-into-main.yml
+++ b/.github/workflows/on-pr-into-main.yml
@@ -5,6 +5,11 @@ env:
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
 


### PR DESCRIPTION
This PR adds the ability for PR checks to be run on pull requests to the main branch even when they are in a draft state. Currently, they only run when the PR is in a "Ready for review" state, which isn't very helpful in instances where you want an easy way of checking the build status of your work on the branch itself, without indicating to other people that you would like your PR to be reviewed.

Corresponding PRs will be made for Utils, API, Admin, and gov.uk/alerts