### PR TITLE
EAS-2637: API: Bump lxml from 4.9.1 to 5.2.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ PyJWT==2.5.0
 SQLAlchemy==1.4.41
 cachetools==5.2.0
 beautifulsoup4==4.11.1
-lxml==4.9.1
+lxml==5.2.2
 pwdpy==1.0.1
 
 notifications-python-client==8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -139,7 +139,7 @@ jsonschema[format]==4.16.0
     # via -r requirements.in
 kombu[sqs]==5.2.4
     # via celery
-lxml==4.9.1
+lxml==5.2.2
     # via -r requirements.in
 mako==1.2.3
     # via alembic


### PR DESCRIPTION
https://github.com/alphagov/emergency-alerts-utils/pull/100 brings in its own requirement on `lxml`, itself brought over from the CBC proxy. This is on 5.2.2, but API specifies the older 4.9.1 which causes a dependency conflict.

I just bump the version here. It seems `lxml` is only used to validate CAP XML in the post schema, and related tests are still passing.