### PR TITLE
Decrease post alert task interval to 1 minute

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -148,7 +148,7 @@ class Config(object):
         "task_queues": [Queue(QUEUE_NAME, Exchange("default"), routing_key=QUEUE_NAME)],
         "worker_max_tasks_per_child": 2,
     }
-    POST_ALERT_CHECK_INTERVAL_MINUTES = 15
+    POST_ALERT_CHECK_INTERVAL_MINUTES = 1
 
     FROM_NUMBER = "development"
 


### PR DESCRIPTION
Based on a standup discussion from the other day. This should reduce the delay between alert expiry and the regeneration of content on gov.uk/alerts, at the expense of possibly queueing regeneration more than once until we receive an acknowledgement.

We have no other type of tasks queued (yet).