### PR TITLE
Move to Postgres archive apt repo to unblock builds

### DIFF
--- a/Dockerfile.eas-api
+++ b/Dockerfile.eas-api
@@ -17,10 +17,12 @@ COPY . $DIR_API
 RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem -O /etc/ssl/certs/global-bundle.pem && \
     update-ca-certificates
 RUN apt-get update
+# We use archive here because our base (Ubuntu Focal as of July 2025) no longer
+# has builds on the main Postgres repository
 RUN apt-get install lsb-release -y && \
     install -d /usr/share/postgresql-common/pgdg && \
-    curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
-    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    curl -o /usr/share/postgresql-common/pgdg/apt-archive.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt-archive.postgresql.org.asc] https://apt-archive.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt update
 
 RUN apt -y install postgresql-client-14 && \


### PR DESCRIPTION
`docker build` fails without this now, due to https://www.postgresql.org/message-id/aItWGvIAWFEsLqds%40msg.df7cb.de

This is a temporary fix - we'll be replatforming base in due course. I've tested this in preview.

<img width="1114" height="590" alt="image" src="https://github.com/user-attachments/assets/39d35afb-3350-406c-a43d-756fd936abb4" />
