### PR TITLE
Add Makefile command for running Flask in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ run-flask: ## Run flask
 	. environment.sh && flask run -p 6011
 
 .PHONY: run-flask-debug
-run-flask: ## Run flask
+run-flask-debug: ## Run flask in debug mode
 	. environment.sh && flask --debug run -p 6011
 
 .PHONY: run-celery


### PR DESCRIPTION
Simple stuff; just adding a standalone Makefile command for running Flask in debug mode, rather than using environment variables and such when developing locally.