### PR TITLE
Adds migration version for adding area column for Templates

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -131,7 +131,7 @@ def create_broadcast_message(service_id):
     if template_id:
         template = dao_get_template_by_id_and_service_id(template_id, data["service_id"])
         content = str(template._as_utils_template())
-        reference = str(template.name)
+        reference = str(template.reference)
     else:
         temporary_template = BroadcastMessageTemplate.from_content(data["content"])
         if temporary_template.content_too_long:

--- a/app/dao/templates_dao.py
+++ b/app/dao/templates_dao.py
@@ -69,7 +69,7 @@ def dao_get_all_templates_for_service(service_id, template_type=None):
         return (
             Template.query.filter_by(service_id=service_id, template_type=template_type, archived=False)
             .order_by(
-                asc(Template.name),
+                asc(Template.reference),
                 asc(Template.template_type),
             )
             .all()
@@ -78,7 +78,7 @@ def dao_get_all_templates_for_service(service_id, template_type=None):
     return (
         Template.query.filter_by(service_id=service_id, archived=False)
         .order_by(
-            asc(Template.name),
+            asc(Template.reference),
             asc(Template.template_type),
         )
         .all()

--- a/app/models.py
+++ b/app/models.py
@@ -555,7 +555,7 @@ class TemplateBase(db.Model):
         super().__init__(**kwargs)
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    name = db.Column(db.String(255), nullable=False)
+    reference = db.Column(db.String(255), nullable=False)
     template_type = db.Column(template_types, nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     updated_at = db.Column(db.DateTime, onupdate=datetime.datetime.utcnow)
@@ -588,7 +588,7 @@ class TemplateBase(db.Model):
             "created_by": self.created_by.email_address,
             "version": self.version,
             "body": self.content,
-            "name": self.name,
+            "reference": self.reference,
         }
 
         return serialized
@@ -968,7 +968,7 @@ class BroadcastMessage(db.Model):
             "service_id": str(self.service_id),
             "template_id": str(self.template_id) if self.template else None,
             "template_version": self.template_version,
-            "template_name": self.template.name if self.template else None,
+            "template_name": self.template.reference if self.template else None,
             "personalisation": self.personalisation if self.template else None,
             "content": self.content,
             "extra_content": self.extra_content or None,

--- a/app/template/rest.py
+++ b/app/template/rest.py
@@ -166,4 +166,4 @@ def purge_templates_and_folders_for_service(service_id):
 
 
 def _template_has_not_changed(current_data, updated_template):
-    return all(current_data[key] == updated_template[key] for key in ("name", "content", "archived"))
+    return all(current_data[key] == updated_template[key] for key in ("reference", "content", "archived"))

--- a/app/template/template_schemas.py
+++ b/app/template/template_schemas.py
@@ -7,14 +7,14 @@ post_create_template_schema = {
     "type": "object",
     "title": "payload for POST /service/<uuid:service_id>/template",
     "properties": {
-        "name": {"type": "string"},
+        "reference": {"type": "string"},
         "template_type": {"enum": TEMPLATE_TYPES},
         "service": uuid,
         "content": {"type": "string"},
         "created_by": uuid,
         "parent_folder_id": uuid,
     },
-    "required": ["name", "template_type", "content", "service", "created_by"],
+    "required": ["reference", "template_type", "content", "service", "created_by"],
 }
 
 post_update_template_schema = {
@@ -24,7 +24,7 @@ post_update_template_schema = {
     "title": "payload for POST /service/<uuid:service_id>/template/<uuid:template_id>",
     "properties": {
         "id": uuid,
-        "name": {"type": "string"},
+        "reference": {"type": "string"},
         "template_type": {"enum": TEMPLATE_TYPES},
         "service": uuid,
         "content": {"type": "string"},

--- a/app/v2/template/template_schemas.py
+++ b/app/v2/template/template_schemas.py
@@ -23,7 +23,7 @@ get_template_by_id_response = {
         "created_by": {"type": "string"},
         "version": {"type": "integer"},
         "body": {"type": "string"},
-        "name": {"type": "string"},
+        "reference": {"type": "string"},
     },
-    "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body", "name"],
+    "required": ["id", "type", "created_at", "updated_at", "version", "created_by", "body", "reference"],
 }

--- a/migrations/versions/0419_add_area_col.py
+++ b/migrations/versions/0419_add_area_col.py
@@ -1,0 +1,28 @@
+"""
+
+Revision ID: 0419_add_area_col
+Revises: 0418_add_message_exclude_col
+Create Date: 2025-08-06 16:23:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0419_add_area_col"
+down_revision = "0418_add_message_exclude_col"
+
+
+def upgrade():
+    op.alter_column("templates", "name", nullable=False, new_column_name="reference")
+    op.alter_column("templates_history", "name", nullable=False, new_column_name="reference")
+    op.add_column("templates", sa.Column("areas", postgresql.JSONB(none_as_null=True, astext_type=sa.Text())))
+    op.add_column("templates_history", sa.Column("areas", postgresql.JSONB(none_as_null=True, astext_type=sa.Text())))
+
+
+def downgrade():
+    op.alter_column("templates", "reference", nullable=False, new_column_name="name")
+    op.alter_column("templates_history", "reference", nullable=False, new_column_name="name")
+    op.drop_column("templates_history", "areas")
+    op.drop_column("templates", "areas")

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -46,7 +46,7 @@ def test_get_broadcast_message(admin_request, sample_broadcast_service):
     assert response["id"] == str(bm.id)
     assert response["template_id"] == str(t.id)
     assert response["content"] == "This is a test"
-    assert response["template_name"] == t.name
+    assert response["template_name"] == t.reference
     assert response["status"] == BroadcastStatusType.DRAFT
     assert response["created_at"] is not None
     assert response["starts_at"] is None
@@ -74,7 +74,7 @@ def test_get_broadcast_message_with_user(mocker, admin_request, sample_broadcast
     assert response["id"] == str(bm.id)
     assert response["template_id"] == str(t.id)
     assert response["content"] == "This is a test"
-    assert response["template_name"] == t.name
+    assert response["template_name"] == t.reference
     assert response["status"] == BroadcastStatusType.DRAFT
     assert response["created_at"] is not None
     assert response["starts_at"] is None
@@ -259,7 +259,7 @@ def test_create_broadcast_message(admin_request, sample_broadcast_service, train
         _expected_status=201,
     )
 
-    assert response["template_name"] == t.name
+    assert response["template_name"] == t.reference
     assert response["status"] == BroadcastStatusType.DRAFT
     assert response["created_at"] is not None
     assert response["created_by_id"] == str(t.created_by_id)
@@ -277,7 +277,7 @@ def test_create_broadcast_message(admin_request, sample_broadcast_service, train
         broadcast_message.id, sample_broadcast_service.id
     )
     broadcast_message_version = dao_get_broadcast_message_version_by_id(latest_version.id)
-    assert broadcast_message_version.reference == t.name
+    assert broadcast_message_version.reference == t.reference
     assert broadcast_message_version.created_by_id == t.created_by_id
     assert broadcast_message_version.created_at is not None
     assert broadcast_message_version.areas == {

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -234,7 +234,7 @@ def sample_template(sample_user):
     service = create_service(service_permissions=[BROADCAST_TYPE], check_if_service_exists=True)
 
     data = {
-        "name": "Template Name",
+        "reference": "Template Name",
         "template_type": BROADCAST_TYPE,
         "content": "This is a template:\nwith a newline",
         "service": service,
@@ -318,7 +318,7 @@ def create_custom_template(service, user, template_config_name, template_type, c
     if not template:
         data = {
             "id": current_app.config[template_config_name],
-            "name": template_config_name,
+            "reference": template_config_name,
             "template_type": template_type,
             "content": content,
             "service": service,

--- a/tests/app/dao/test_templates_dao.py
+++ b/tests/app/dao/test_templates_dao.py
@@ -17,7 +17,7 @@ from tests.app.db import create_template, create_template_folder
 
 def test_create_template(sample_service, sample_user):
     data = {
-        "name": "Sample Template",
+        "reference": "Sample Template",
         "template_type": "broadcast",
         "content": "Template content",
         "service": sample_service,
@@ -28,12 +28,12 @@ def test_create_template(sample_service, sample_user):
 
     assert Template.query.count() == 1
     assert len(dao_get_all_templates_for_service(sample_service.id)) == 1
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == "Sample Template"
+    assert dao_get_all_templates_for_service(sample_service.id)[0].reference == "Sample Template"
 
 
 def test_update_template(sample_service, sample_user):
     data = {
-        "name": "Sample Template",
+        "reference": "Sample Template",
         "template_type": "broadcast",
         "content": "Template content",
         "service": sample_service,
@@ -42,11 +42,11 @@ def test_update_template(sample_service, sample_user):
     template = Template(**data)
     dao_create_template(template)
     created = dao_get_all_templates_for_service(sample_service.id)[0]
-    assert created.name == "Sample Template"
+    assert created.reference == "Sample Template"
 
-    created.name = "new name"
+    created.reference = "new name"
     dao_update_template(created)
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == "new name"
+    assert dao_get_all_templates_for_service(sample_service.id)[0].reference == "new name"
 
 
 def test_get_all_templates_for_service(service_factory):
@@ -93,14 +93,14 @@ def test_get_all_templates_for_service_is_alphabetised(sample_service):
     )
 
     assert Template.query.count() == 3
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == "Sample Template 1"
-    assert dao_get_all_templates_for_service(sample_service.id)[1].name == "Sample Template 2"
-    assert dao_get_all_templates_for_service(sample_service.id)[2].name == "Sample Template 3"
+    assert dao_get_all_templates_for_service(sample_service.id)[0].reference == "Sample Template 1"
+    assert dao_get_all_templates_for_service(sample_service.id)[1].reference == "Sample Template 2"
+    assert dao_get_all_templates_for_service(sample_service.id)[2].reference == "Sample Template 3"
 
-    template_2.name = "AAAAA Sample Template 2"
+    template_2.reference = "AAAAA Sample Template 2"
     dao_update_template(template_2)
-    assert dao_get_all_templates_for_service(sample_service.id)[0].name == "AAAAA Sample Template 2"
-    assert dao_get_all_templates_for_service(sample_service.id)[1].name == "Sample Template 1"
+    assert dao_get_all_templates_for_service(sample_service.id)[0].reference == "AAAAA Sample Template 2"
+    assert dao_get_all_templates_for_service(sample_service.id)[1].reference == "Sample Template 1"
 
 
 def test_get_all_returns_empty_list_if_no_templates(sample_service):
@@ -125,7 +125,7 @@ def test_get_template_by_id_and_service(sample_service):
     sample_template = create_template(template_name="Test Template", service=sample_service)
     template = dao_get_template_by_id_and_service_id(template_id=sample_template.id, service_id=sample_service.id)
     assert template.id == sample_template.id
-    assert template.name == "Test Template"
+    assert template.reference == "Test Template"
     assert template.version == sample_template.version
 
 
@@ -139,7 +139,7 @@ def test_create_template_creates_a_history_record_with_current_data(sample_servi
     assert Template.query.count() == 0
     assert TemplateHistory.query.count() == 0
     data = {
-        "name": "Sample Template",
+        "reference": "Sample Template",
         "template_type": "broadcast",
         "content": "Template content",
         "service": sample_service,
@@ -154,7 +154,7 @@ def test_create_template_creates_a_history_record_with_current_data(sample_servi
     template_history = TemplateHistory.query.first()
 
     assert template_from_db.id == template_history.id
-    assert template_from_db.name == template_history.name
+    assert template_from_db.reference == template_history.reference
     assert template_from_db.version == 1
     assert template_from_db.version == template_history.version
     assert sample_user.id == template_history.created_by_id
@@ -165,7 +165,7 @@ def test_update_template_creates_a_history_record_with_current_data(sample_servi
     assert Template.query.count() == 0
     assert TemplateHistory.query.count() == 0
     data = {
-        "name": "Sample Template",
+        "reference": "Sample Template",
         "template_type": "broadcast",
         "content": "Template content",
         "service": sample_service,
@@ -175,12 +175,12 @@ def test_update_template_creates_a_history_record_with_current_data(sample_servi
     dao_create_template(template)
 
     created = dao_get_all_templates_for_service(sample_service.id)[0]
-    assert created.name == "Sample Template"
+    assert created.reference == "Sample Template"
     assert Template.query.count() == 1
     assert Template.query.first().version == 1
     assert TemplateHistory.query.count() == 1
 
-    created.name = "new name"
+    created.reference = "new name"
     dao_update_template(created)
 
     assert Template.query.count() == 1
@@ -190,8 +190,8 @@ def test_update_template_creates_a_history_record_with_current_data(sample_servi
 
     assert template_from_db.version == 2
 
-    assert TemplateHistory.query.filter_by(name="Sample Template").one().version == 1
-    assert TemplateHistory.query.filter_by(name="new name").one().version == 2
+    assert TemplateHistory.query.filter_by(reference="Sample Template").one().version == 1
+    assert TemplateHistory.query.filter_by(reference="new name").one().version == 2
 
 
 def test_get_template_history_version(sample_user, sample_service, sample_template):
@@ -229,7 +229,7 @@ def test_purge_templates_for_service(sample_user, sample_service):
     folder_1 = create_template_folder(sample_service, name="folder_1", users=[service_user])
 
     data = {
-        "name": "Sample Template 1",
+        "reference": "Sample Template 1",
         "template_type": "broadcast",
         "content": "Alert template content",
         "service": sample_service,
@@ -240,7 +240,7 @@ def test_purge_templates_for_service(sample_user, sample_service):
     dao_create_template(template)
 
     data = {
-        "name": "Sample Template 2",
+        "reference": "Sample Template 2",
         "template_type": "broadcast",
         "content": "Alert template content",
         "service": sample_service,

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -118,7 +118,7 @@ def create_template(
     folder=None,
 ):
     data = {
-        "name": template_name or "{} Template Name".format(template_type),
+        "reference": template_name or "{} Template Name".format(template_type),
         "template_type": template_type,
         "content": content,
         "service": service,
@@ -304,7 +304,7 @@ def create_broadcast_message(
         template_id = template.id
         template_version = template.version
         content = template.content
-        reference = template.name
+        reference = template.reference
     elif content:
         template_id = None
         template_version = None

--- a/tests/app/template/test_rest.py
+++ b/tests/app/template/test_rest.py
@@ -20,7 +20,7 @@ from tests.app.db import create_service, create_template, create_template_folder
 def test_should_create_a_new_template_for_a_service(client, sample_user):
     service = create_service(service_permissions=[BROADCAST_TYPE])
     data = {
-        "name": "my template",
+        "reference": "my template",
         "template_type": BROADCAST_TYPE,
         "content": "template <b>content</b>",
         "service": str(service.id),
@@ -36,7 +36,7 @@ def test_should_create_a_new_template_for_a_service(client, sample_user):
     )
     assert response.status_code == 201
     json_resp = json.loads(response.get_data(as_text=True))
-    assert json_resp["data"]["name"] == "my template"
+    assert json_resp["data"]["reference"] == "my template"
     assert json_resp["data"]["template_type"] == BROADCAST_TYPE
     assert json_resp["data"]["content"] == "template <b>content</b>"
     assert json_resp["data"]["service"] == str(service.id)
@@ -54,7 +54,7 @@ def test_create_a_new_template_for_a_service_adds_folder_relationship(client, sa
     parent_folder = create_template_folder(service=sample_service, name="parent folder")
 
     data = {
-        "name": "my template",
+        "reference": "my template",
         "template_type": "broadcast",
         "content": "template <b>content</b>",
         "service": str(sample_service.id),
@@ -70,7 +70,7 @@ def test_create_a_new_template_for_a_service_adds_folder_relationship(client, sa
         data=data,
     )
     assert response.status_code == 201
-    template = Template.query.filter(Template.name == "my template").first()
+    template = Template.query.filter(Template.reference == "my template").first()
     assert template.folder == parent_folder
 
 
@@ -79,7 +79,7 @@ def test_create_template_should_return_400_if_folder_is_for_a_different_service(
     parent_folder = create_template_folder(service=service2)
 
     data = {
-        "name": "my template",
+        "reference": "my template",
         "template_type": "broadcast",
         "content": "template <b>content</b>",
         "service": str(sample_service.id),
@@ -100,7 +100,7 @@ def test_create_template_should_return_400_if_folder_is_for_a_different_service(
 
 def test_create_template_should_return_400_if_folder_does_not_exist(client, sample_service):
     data = {
-        "name": "my template",
+        "reference": "my template",
         "template_type": "broadcast",
         "content": "template content",
         "service": str(sample_service.id),
@@ -121,7 +121,7 @@ def test_create_template_should_return_400_if_folder_does_not_exist(client, samp
 
 def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_user, fake_uuid):
     data = {
-        "name": "my template",
+        "reference": "my template",
         "template_type": BROADCAST_TYPE,
         "content": "template content",
         "service": fake_uuid,
@@ -152,7 +152,7 @@ def test_should_raise_error_if_service_does_not_exist_on_create(client, sample_u
 def test_should_raise_error_on_create_if_no_permission(client, sample_user, permissions, template_type, expected_error):
     service = create_service(service_permissions=permissions)
     data = {
-        "name": "my template",
+        "reference": "my template",
         "template_type": template_type,
         "content": "template content",
         "service": str(service.id),
@@ -212,7 +212,7 @@ def test_should_be_error_on_update_if_no_permission(
 def test_should_error_if_created_by_missing(client, sample_user, sample_service):
     service_id = str(sample_service.id)
     data = {
-        "name": "my template",
+        "reference": "my template",
         "template_type": BROADCAST_TYPE,
         "content": "template content",
         "service": service_id,
@@ -232,7 +232,7 @@ def test_should_error_if_created_by_missing(client, sample_user, sample_service)
 
 
 def test_should_be_error_if_service_does_not_exist_on_update(client, fake_uuid):
-    data = {"name": "my template"}
+    data = {"reference": "my template"}
     data = json.dumps(data)
     auth_header = create_admin_authorization_header()
 
@@ -267,7 +267,7 @@ def test_update_should_update_a_template(client, sample_user):
     assert update_response.status_code == 200
     update_json_resp = json.loads(update_response.get_data(as_text=True))
     assert update_json_resp["data"]["content"] == ("my template has new content")
-    assert update_json_resp["data"]["name"] == template.name
+    assert update_json_resp["data"]["reference"] == template.reference
     assert update_json_resp["data"]["template_type"] == template.template_type
     assert update_json_resp["data"]["version"] == 2
 
@@ -280,7 +280,7 @@ def test_update_should_update_a_template(client, sample_user):
 
 def test_should_be_able_to_archive_template(client, sample_template):
     data = {
-        "name": sample_template.name,
+        "reference": sample_template.reference,
         "template_type": sample_template.template_type,
         "content": sample_template.content,
         "archived": True,
@@ -323,7 +323,7 @@ def test_should_be_able_to_archive_template_should_remove_template_folders(clien
 
 def test_should_be_able_to_get_all_templates_for_a_service(client, sample_user, sample_service):
     data = {
-        "name": "my template 1",
+        "reference": "my template 1",
         "template_type": BROADCAST_TYPE,
         "content": "template content",
         "service": str(sample_service.id),
@@ -331,7 +331,7 @@ def test_should_be_able_to_get_all_templates_for_a_service(client, sample_user, 
     }
     data_1 = json.dumps(data)
     data = {
-        "name": "my template 2",
+        "reference": "my template 2",
         "template_type": BROADCAST_TYPE,
         "content": "template content",
         "service": str(sample_service.id),
@@ -358,10 +358,10 @@ def test_should_be_able_to_get_all_templates_for_a_service(client, sample_user, 
 
     assert response.status_code == 200
     update_json_resp = json.loads(response.get_data(as_text=True))
-    assert update_json_resp["data"][0]["name"] == "my template 1"
+    assert update_json_resp["data"][0]["reference"] == "my template 1"
     assert update_json_resp["data"][0]["version"] == 1
     assert update_json_resp["data"][0]["created_at"]
-    assert update_json_resp["data"][1]["name"] == "my template 2"
+    assert update_json_resp["data"][1]["reference"] == "my template 2"
     assert update_json_resp["data"][1]["version"] == 1
     assert update_json_resp["data"][1]["created_at"]
 
@@ -409,7 +409,7 @@ def test_should_get_return_all_fields_by_default(
         "created_by",
         "folder",
         "id",
-        "name",
+        "reference",
         "service",
         "template_type",
         "updated_at",
@@ -462,7 +462,7 @@ def test_create_400_for_over_limit_content(
         random.choice(string.ascii_uppercase + string.digits) for _ in range(MAX_BROADCAST_CHAR_COUNT + 1)
     )
     data = {
-        "name": "too big template",
+        "reference": "too big template",
         "template_type": BROADCAST_TYPE,
         "content": content,
         "service": str(sample_service.id),
@@ -554,7 +554,7 @@ def test_update_does_not_create_new_version_when_there_is_no_change(client, samp
         (
             {},
             [
-                {"error": "ValidationError", "message": "name is a required property"},
+                {"error": "ValidationError", "message": "reference is a required property"},
                 {"error": "ValidationError", "message": "template_type is a required property"},
                 {"error": "ValidationError", "message": "content is a required property"},
                 {"error": "ValidationError", "message": "service is a required property"},
@@ -571,7 +571,7 @@ def test_update_does_not_create_new_version_when_there_is_no_change(client, samp
             [
                 {
                     "error": "ValidationError",
-                    "message": "name is a required property",
+                    "message": "reference is a required property",
                 },
             ],
         ),

--- a/tests/app/v2/template/test_template_schemas.py
+++ b/tests/app/v2/template/test_template_schemas.py
@@ -19,7 +19,7 @@ valid_json_get_response = {
     "version": 1,
     "created_by": "someone@test.com",
     "body": "some body",
-    "name": "some name",
+    "reference": "some reference",
 }
 
 valid_json_get_response_with_optionals = {
@@ -31,7 +31,7 @@ valid_json_get_response_with_optionals = {
     "created_by": "someone",
     "body": "some body",
     "subject": "some subject",
-    "name": "some name",
+    "reference": "some reference",
 }
 
 valid_request_args = [{"id": str(uuid.uuid4()), "version": 1}, {"id": str(uuid.uuid4())}]

--- a/tests/app/v2/templates/test_templates_schemas.py
+++ b/tests/app/v2/templates/test_templates_schemas.py
@@ -22,7 +22,7 @@ valid_json_get_all_response = [
                 "version": 1,
                 "created_by": "someone@test.com",
                 "body": "some body",
-                "name": "some name",
+                "reference": "some reference",
             },
             {
                 "id": str(uuid.uuid4()),
@@ -33,7 +33,7 @@ valid_json_get_all_response = [
                 "created_by": "someone@test.com",
                 "subject": "test subject",
                 "body": "some body",
-                "name": "some name",
+                "reference": "some reference",
             },
         ]
     },
@@ -47,7 +47,7 @@ valid_json_get_all_response = [
                 "version": 2,
                 "created_by": "someone@test.com",
                 "body": "some body",
-                "name": "some name",
+                "reference": "some reference",
             }
         ]
     },
@@ -66,7 +66,7 @@ invalid_json_get_all_response = [
                     "version": 1,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -83,7 +83,7 @@ invalid_json_get_all_response = [
                     "version": "invalid_version",
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -100,7 +100,7 @@ invalid_json_get_all_response = [
                     "version": 1,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -117,7 +117,7 @@ invalid_json_get_all_response = [
                     "version": 1,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -137,7 +137,7 @@ invalid_json_get_all_response = [
                 }
             ]
         },
-        ["templates name is a required property"],
+        ["templates reference is a required property"],
     ),
     (
         {
@@ -149,7 +149,7 @@ invalid_json_get_all_response = [
                     "version": 1,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -165,7 +165,7 @@ invalid_json_get_all_response = [
                     "version": 1,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -181,7 +181,7 @@ invalid_json_get_all_response = [
                     "version": 1,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -197,7 +197,7 @@ invalid_json_get_all_response = [
                     "updated_at": None,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -213,7 +213,7 @@ invalid_json_get_all_response = [
                     "updated_at": None,
                     "version": 1,
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -229,7 +229,7 @@ invalid_json_get_all_response = [
                     "updated_at": None,
                     "version": 1,
                     "created_by": "someone@test.com",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },
@@ -244,7 +244,7 @@ invalid_json_get_all_response = [
                     "updated_at": None,
                     "created_by": "someone@test.com",
                     "body": "some body",
-                    "name": "some name",
+                    "reference": "some reference",
                 }
             ]
         },


### PR DESCRIPTION
This PR adds the migration version that adds the areas column to both `templates` and `template_history`, as well as renaming the "name" column to "reference".