### PR TITLE
Remove deprecated runbook link

### DIFF
--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -96,9 +96,6 @@ def _create_p1_zendesk_alert(broadcast_message):
         Sent on channel {broadcast_message.service.broadcast_channel} to {broadcast_message.areas["names"]}.
 
         Content starts "{broadcast_message.content[:100]}".
-
-        Follow the runbook to check the broadcast went out OK:
-        https://docs.google.com/document/d/1J99yOlfp4nQz6et0w5oJVqi-KywtIXkxrEIyq_g2XUs/edit#heading=h.lzr9aq5b4wg
     """
     )
 


### PR DESCRIPTION
Removing the link to a deprecated runbook. Most of its contents no longer apply to the system as it is today.