### PR TITLE
EAS-2074 Add PostGIS extension

### DIFF
--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -11,7 +11,8 @@ services:
       - test-network
 
   pg:
-    image: postgres:14
+    image: postgis/postgis:14-3.5
+    platform: linux/amd64
     container_name: postgres-for-api-tests
     restart: always
     environment:

--- a/migrations/versions/0421_add_postgis_extension.py
+++ b/migrations/versions/0421_add_postgis_extension.py
@@ -1,0 +1,28 @@
+"""
+
+Revision ID: 0421_add_postgis_extension
+Revises: 0420_add_default_template_areas
+Create Date: 2025-09-10 15:51:00
+
+"""
+
+from alembic import op
+
+revision = "0421_add_postgis_extension"
+down_revision = "0420_add_default_template_areas"
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE EXTENSION IF NOT EXISTS postgis
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        DROP EXTENSION IF EXISTS postgis
+        """
+    )

--- a/tests/app/test_db.py
+++ b/tests/app/test_db.py
@@ -2,5 +2,44 @@ def test_postgis_extension_added_to_db(
     notify_db_session,
 ):
     result = notify_db_session.execute("SELECT extname FROM pg_extension WHERE extname='postgis'").one()
-    assert result is not None
     assert result[0] == "postgis"
+
+
+def test_postgis_version_returns_version(
+    notify_db_session,
+):
+    result = notify_db_session.execute("SELECT postgis_version()").one()
+    assert "3.5 " in result[0]  # Asserts that PostGIS version is same as specified in docker-compose-tests.yml
+
+
+def test_st_astext_returns_point_wkt(
+    notify_db_session,
+):
+    # Asserts that ST_AsText and ST_GeomFromText are present,
+    # as are provided by PostGIS extension, and converts geometry to WKT
+    result = notify_db_session.execute("SELECT ST_AsText(ST_GeomFromText('POINT(0 0)', 4326))").one()
+    assert result[0] == "POINT(0 0)"
+
+
+def test_st_area_function_computes_area_of_polygon(notify_db_session):
+    # Asserts that ST_Area functions present, provided by PostGIS extension,
+    # and computes area of a polygon geometry, in this case a shape with area of 1
+    result = notify_db_session.execute(
+        "SELECT ST_Area(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 4326))"
+    ).one()
+    assert int(result[0]) == 1
+
+
+def test_st_intersects_function_detects_overlapping_geometries(notify_db_session):
+    # Asserts that ST_Intersects functions present, provided by PostGIS extension,
+    # and detects if geometries overlap
+    result = notify_db_session.execute(
+        "SELECT ST_Intersects(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 4326), "
+        "ST_GeomFromText('POLYGON((0 2, 1 2, 1 3, 0 3, 0 2))', 4326))"
+    ).one()
+    assert result[0] is False  # The 2 polygons don't intersect
+    result = notify_db_session.execute(
+        "SELECT ST_Intersects(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))', 4326), "
+        "ST_GeomFromText('POLYGON((0 0, 1 2, 1 3, 0 3, 0 0))', 4326))"
+    ).one()
+    assert result[0] is True  # The 2 polygons intersect at 0,0

--- a/tests/app/test_db.py
+++ b/tests/app/test_db.py
@@ -1,0 +1,6 @@
+def test_postgis_extension_added_to_db(
+    notify_db_session,
+):
+    result = notify_db_session.execute("SELECT extname FROM pg_extension WHERE extname='postgis'").one()
+    assert result is not None
+    assert result[0] == "postgis"


### PR DESCRIPTION
This PR consists of the following:
- Adds a migration version for adding the PostGIS extension to the database
- Adds tests asserting that extension has been added and the functions, that it provides, are present
- Updates image for database test container, to use image that supports PostGIS extension