### PR TITLE
EAS-2767: API: Update Dependabot to ignore the local utils dep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     rebase-strategy: "auto"
     exclude-paths:
       # Dependabot fails completely as it contains a local path
-      - /requirements_local_utils.txt
+      - requirements_local_utils.txt
     groups:
       pip-security:
         applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,15 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
+    exclude-paths:
+      # Dependabot fails completely as it contains a local path
+      - /requirements_local_utils.txt
     groups:
       pip-security:
         applies-to: security-updates


### PR DESCRIPTION
See https://github.com/alphagov/emergency-alerts-api/network/updates/1114953606 / #250

Quite why Dependabot fails the entire run if can't resolve one dependency I've no idea, but there we are.