### PR TITLE
EAS-2837: Post DB migration version as a healthcheck metric

### DIFF
--- a/app/celery/scheduled_tasks.py
+++ b/app/celery/scheduled_tasks.py
@@ -29,13 +29,18 @@ from app.dao.users_dao import (
     save_model_user,
 )
 from app.models import BroadcastMessage, BroadcastStatusType, Event
-from app.status.healthcheck import post_version_to_cloudwatch
+from app.status.healthcheck import (
+    get_db_version,
+    post_app_version_to_cloudwatch,
+    post_db_version_to_cloudwatch,
+)
 
 
 @notify_celery.task(name=TaskNames.RUN_HEALTH_CHECK)
 def run_health_check():
     try:
-        post_version_to_cloudwatch()
+        post_app_version_to_cloudwatch()
+        post_db_version_to_cloudwatch(get_db_version())
 
         time_stamp = int(time.time())
         with open("/eas/emergency-alerts-api/celery-beat-healthcheck", mode="w") as file:


### PR DESCRIPTION
This introduces a new metric, `DBVersion`, that's published alongside the existing `AppVersion` metric. It does exactly as you expect, emitting the current DB migration name that's stored on every healthcheck invocation.

<img width="1679" height="589" alt="image" src="https://github.com/user-attachments/assets/b9994a30-678a-48b4-bbb2-8cc8f5a3632b" />
