### PR TITLE
EAS-2996: Store all statuses for a provider's broadcast message

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -110,7 +110,7 @@ def get_broadcast_provider_messages(service_id, broadcast_message_id):
             {
                 "id": message.id,
                 "provider": message.provider,
-                "status": message.status,
+                "status": message.get_latest_status_entry().status,
             }
             for message in messages
         ]

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -7,14 +7,17 @@ from flask import current_app
 from app import cbc_proxy_client, notify_celery
 from app.clients.cbc_proxy import CBCProxyRetryableException
 from app.dao.broadcast_message_dao import (
+    add_broadcast_provider_message_status,
     create_broadcast_provider_message,
     dao_get_broadcast_event_by_id,
-    update_broadcast_provider_message_status,
 )
 from app.models import (
+    BROADCAST_PROVIDER_STATUS_ACK,
+    BROADCAST_PROVIDER_STATUS_SENDING,
+    BroadcastEvent,
     BroadcastEventMessageType,
     BroadcastProvider,
-    BroadcastProviderMessageStatus,
+    BroadcastProviderMessage,
 )
 from app.utils import format_sequential_number, is_local_host
 
@@ -41,7 +44,7 @@ def check_event_is_authorised_to_be_sent(broadcast_event, provider):
         )
 
 
-def check_event_makes_sense_in_sequence(broadcast_event, provider):
+def check_event_makes_sense_in_sequence(broadcast_event: BroadcastEvent, provider: str):
     """
     If any previous event hasn't sent yet for that provider, then we shouldn't send the current event. Instead, fail and
     raise a zendesk ticket - so that a notify team member can assess the state of the previous messages, and if
@@ -60,13 +63,15 @@ def check_event_makes_sense_in_sequence(broadcast_event, provider):
     4. If you need to re-send this task off again, you'll need to run the following command on paas:
        `send_broadcast_provider_message.apply_async(args=(broadcast_event_id, provider), queue=QueueNames.BROADCASTS)`
     """
-    current_provider_message = broadcast_event.get_provider_message(provider)
+    current_provider_message: BroadcastProviderMessage | None = broadcast_event.get_provider_message(provider)
+    current_provider_status = current_provider_message.get_latest_status_entry() if current_provider_message else None
+
     # if this is the first time a task is being executed, it won't have a provider message yet
-    if current_provider_message and current_provider_message.status != BroadcastProviderMessageStatus.SENDING:
+    if current_provider_status and current_provider_status.status != BROADCAST_PROVIDER_STATUS_SENDING:
         raise BroadcastIntegrityError(
             f"Cannot send broadcast_event {broadcast_event.id} "
             + f"to provider {provider}: "
-            + f"It is in status {current_provider_message.status}"
+            + f"It is in status {current_provider_status.status}"
         )
 
     if broadcast_event.transmitted_finishes_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
@@ -82,7 +87,7 @@ def check_event_makes_sense_in_sequence(broadcast_event, provider):
     for prev_event in events:
         if prev_event.id != broadcast_event.id and prev_event.sent_at < broadcast_event.sent_at:
             # get the record from when that event was sent to the same provider
-            prev_provider_message = prev_event.get_provider_message(provider)
+            prev_provider_message: BroadcastProviderMessage | None = prev_event.get_provider_message(provider)
 
             # the previous message hasn't even got round to running `send_broadcast_provider_message` yet.
             if not prev_provider_message:
@@ -95,11 +100,12 @@ def check_event_makes_sense_in_sequence(broadcast_event, provider):
 
             # if there's a previous message that has started but not finished sending (whether it fatally errored or is
             # currently retrying)
-            if prev_provider_message.status != BroadcastProviderMessageStatus.ACK:
+            prev_provider_message_status = prev_provider_message.get_latest_status_entry()
+            if prev_provider_message_status.status != BROADCAST_PROVIDER_STATUS_ACK:
                 raise BroadcastIntegrityError(
                     f"Cannot send {broadcast_event.id}. Previous event {prev_event.id} "
                     + f"(type {prev_event.message_type}) has not finished sending to provider {provider} yet.\n"
-                    + f'It is currently in status "{prev_provider_message.status}".\n'
+                    + f'It is currently in status "{prev_provider_message_status.status}".\n'
                     + "You must ensure that the other event sends succesfully, then manually kick off this event "
                     + "again by re-running send_broadcast_provider_message for this event and provider."
                 )
@@ -233,7 +239,7 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
                     sent=broadcast_event.sent_at_as_cap_datetime_string,
                 )
 
-        update_broadcast_provider_message_status(broadcast_provider_message, status=BroadcastProviderMessageStatus.ACK)
+        add_broadcast_provider_message_status(broadcast_provider_message, status=BROADCAST_PROVIDER_STATUS_ACK)
     except Exception as e:
         current_app.logger.exception(
             f"Failed to send provider message (event {broadcast_event_id}, provider {provider})",

--- a/app/celery/broadcast_message_tasks.py
+++ b/app/celery/broadcast_message_tasks.py
@@ -13,6 +13,7 @@ from app.dao.broadcast_message_dao import (
 )
 from app.models import (
     BROADCAST_PROVIDER_STATUS_ACK,
+    BROADCAST_PROVIDER_STATUS_ERR,
     BROADCAST_PROVIDER_STATUS_SENDING,
     BroadcastEvent,
     BroadcastEventMessageType,
@@ -169,6 +170,8 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
         )
         return
 
+    broadcast_provider_message = None
+
     try:
         broadcast_event = dao_get_broadcast_event_by_id(broadcast_event_id)
 
@@ -241,13 +244,23 @@ def send_broadcast_provider_message(self, broadcast_event_id, provider):
 
         add_broadcast_provider_message_status(broadcast_provider_message, status=BROADCAST_PROVIDER_STATUS_ACK)
     except Exception as e:
+        exception_detail = getattr(e, "message", repr(e))
+
         current_app.logger.exception(
             f"Failed to send provider message (event {broadcast_event_id}, provider {provider})",
             extra={
                 "python_module": __name__,
-                "exception": str(e),
+                "exception": exception_detail,
             },
         )
+
+        if broadcast_provider_message is not None:
+            add_broadcast_provider_message_status(
+                broadcast_provider_message,
+                status=BROADCAST_PROVIDER_STATUS_ERR,
+                error_detail={"exception": exception_detail},
+            )
+
         raise
 
 

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -139,10 +139,10 @@ def dao_get_broadcast_messages_for_service_with_user(service_id):
 
 def dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id):
     return (
-        db.session.query(
-            BroadcastProviderMessage.id,
-            BroadcastProviderMessage.provider,
-            BroadcastProviderMessage.status,
+        db.session.query(BroadcastProviderMessage)
+        .join(
+            BroadcastProviderMessageStatus,
+            BroadcastProviderMessageStatus.broadcast_provider_message_id == BroadcastProviderMessage.id,
         )
         .join(BroadcastEvent, BroadcastEvent.id == BroadcastProviderMessage.broadcast_event_id)
         .filter(BroadcastEvent.broadcast_message_id == broadcast_message_id)
@@ -444,11 +444,16 @@ def _delete_broadcast_provider_message_numbers(broadcast_provider_message_ids, d
 
 
 def _delete_broadcast_provider_messages(broadcast_provider_message_ids, dry_run=False):
+    statuses = db.session.query(BroadcastProviderMessageStatus).filter(
+        BroadcastProviderMessageStatus.broadcast_provider_message_id.in_(broadcast_provider_message_ids)
+    )
+
     bpm = db.session.query(BroadcastProviderMessage).filter(
         BroadcastProviderMessage.id.in_(broadcast_provider_message_ids)
     )
     item_count = len(bpm.all())
     if not dry_run:
+        statuses.delete(synchronize_session=False)
         bpm.delete(synchronize_session=False)
     return item_count
 

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -365,13 +365,16 @@ def create_broadcast_provider_message(broadcast_event: BroadcastEvent, provider:
 
 
 @autocommit
-def add_broadcast_provider_message_status(broadcast_provider_message: BroadcastProviderMessage, *, status: str):
+def add_broadcast_provider_message_status(
+    broadcast_provider_message: BroadcastProviderMessage, *, status: str, error_detail=None
+):
     """
     Assumes broadcast_provider_message is in the database session already
     """
     new_status = BroadcastProviderMessageStatus(
         broadcast_provider_message=broadcast_provider_message,
         status=status,
+        error_detail=error_detail,
     )
     broadcast_provider_message.statuses.append(new_status)
 

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import aliased
 from app import db
 from app.dao.dao_utils import autocommit
 from app.models import (
+    BROADCAST_PROVIDER_STATUS_SENDING,
     BroadcastEvent,
     BroadcastMessage,
     BroadcastProvider,
@@ -341,13 +342,15 @@ def get_earlier_events_for_broadcast_event(broadcast_event_id):
 
 
 @autocommit
-def create_broadcast_provider_message(broadcast_event, provider):
+def create_broadcast_provider_message(broadcast_event: BroadcastEvent, provider: str):
+    broadcast_provider_message_status = BroadcastProviderMessageStatus(status=BROADCAST_PROVIDER_STATUS_SENDING)
+
     broadcast_provider_message_id = uuid.uuid4()
     provider_message = BroadcastProviderMessage(
         id=broadcast_provider_message_id,
         broadcast_event=broadcast_event,
         provider=provider,
-        status=BroadcastProviderMessageStatus.SENDING,
+        statuses=[broadcast_provider_message_status],
     )
     db.session.add(provider_message)
     db.session.commit()
@@ -362,8 +365,15 @@ def create_broadcast_provider_message(broadcast_event, provider):
 
 
 @autocommit
-def update_broadcast_provider_message_status(broadcast_provider_message, *, status):
-    broadcast_provider_message.status = status
+def add_broadcast_provider_message_status(broadcast_provider_message: BroadcastProviderMessage, *, status: str):
+    """
+    Assumes broadcast_provider_message is in the database session already
+    """
+    new_status = BroadcastProviderMessageStatus(
+        broadcast_provider_message=broadcast_provider_message,
+        status=status,
+    )
+    broadcast_provider_message.statuses.append(new_status)
 
 
 def _resolve_service_id(service):

--- a/app/models.py
+++ b/app/models.py
@@ -1175,14 +1175,39 @@ class BroadcastProvider:
 
 ALL_BROADCAST_PROVIDERS = BroadcastProvider.PROVIDERS
 
+BROADCAST_PROVIDER_STATUS_TECHNICAL_FAILURE = "technical-failure"  # Couldn't send (cbc proxy 5xx/4xx)
+BROADCAST_PROVIDER_STATUS_SENDING = "sending"  # Sent to cbc, awaiting response
+BROADCAST_PROVIDER_STATUS_ACK = "returned-ack"  # Received ack response
+BROADCAST_PROVIDER_STATUS_ERR = "returned-error"  # Received error response
 
-class BroadcastProviderMessageStatus:
-    TECHNICAL_FAILURE = "technical-failure"  # Couldn’t send (cbc proxy 5xx/4xx)
-    SENDING = "sending"  # Sent to cbc, awaiting response
-    ACK = "returned-ack"  # Received ack response
-    ERR = "returned-error"  # Received error response
+ALL_BROADCAST_PROVIDER_STATUSES = [
+    BROADCAST_PROVIDER_STATUS_TECHNICAL_FAILURE,
+    BROADCAST_PROVIDER_STATUS_SENDING,
+    BROADCAST_PROVIDER_STATUS_ACK,
+    BROADCAST_PROVIDER_STATUS_ERR,
+]
 
-    STATES = [TECHNICAL_FAILURE, SENDING, ACK, ERR]
+
+class BroadcastProviderMessageStatus(db.Model):
+    """
+    Represents a status update to a parent BroadcastProviderMessage, from which timings between
+    events and retry attempts can be interpreted between rows.
+    """
+
+    __tablename__ = "broadcast_provider_message_status"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    broadcast_provider_message_id = db.Column(UUID(as_uuid=True), db.ForeignKey("broadcast_provider_message.id"))
+    broadcast_provider_message = db.relationship("BroadcastProviderMessage", back_populates="statuses")
+
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now)
+
+    status = db.Column(
+        db.Enum(*ALL_BROADCAST_PROVIDER_STATUSES, name="broadcast_provider_message_status_types"), nullable=False
+    )
+    # Only set for errors:
+    error_detail = db.Column(JSONB(none_as_null=True), nullable=True)
 
 
 class BroadcastProviderMessage(db.Model):
@@ -1200,10 +1225,9 @@ class BroadcastProviderMessage(db.Model):
     # 'ee', 'three', 'vodafone', etc
     provider = db.Column(db.String)
 
-    status = db.Column(db.String)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now)
 
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow)
+    statuses = db.relationship("BroadcastProviderMessageStatus", back_populates="broadcast_provider_message")
 
     UniqueConstraint(broadcast_event_id, provider)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1196,7 +1196,11 @@ class BroadcastProviderMessageStatus(db.Model):
 
     __tablename__ = "broadcast_provider_message_status"
 
-    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # We use a sequence instead of UUID as we need something to order, and datetime
+    # may not have the accuracy (and in unit tests with frozen time is awkward)
+    sequence = Sequence("broadcast_provider_message_status_seq")
+
+    id = db.Column(db.Integer, sequence, server_default=sequence.next_value(), primary_key=True)
 
     broadcast_provider_message_id = db.Column(UUID(as_uuid=True), db.ForeignKey("broadcast_provider_message.id"))
     broadcast_provider_message = db.relationship("BroadcastProviderMessage", back_populates="statuses")
@@ -1227,7 +1231,12 @@ class BroadcastProviderMessage(db.Model):
 
     created_at = db.Column(db.DateTime, nullable=False, default=utc_now)
 
-    statuses = db.relationship("BroadcastProviderMessageStatus", back_populates="broadcast_provider_message")
+    statuses = db.relationship(
+        "BroadcastProviderMessageStatus",
+        back_populates="broadcast_provider_message",
+        # Newest ones at the end
+        order_by="asc(BroadcastProviderMessageStatus.id)",
+    )
 
     UniqueConstraint(broadcast_event_id, provider)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1242,6 +1242,9 @@ class BroadcastProviderMessage(db.Model):
 
     message_number = association_proxy("broadcast_provider_message_number", "broadcast_provider_message_number")
 
+    def get_latest_status_entry(self) -> BroadcastProviderMessageStatus | None:
+        return self.statuses[-1] if len(self.statuses) > 0 else None
+
 
 class BroadcastProviderMessageNumber(db.Model):
     """

--- a/migrations/versions/0423_add_broadcast_provider_message_status.py
+++ b/migrations/versions/0423_add_broadcast_provider_message_status.py
@@ -1,0 +1,98 @@
+"""
+
+Revision ID: 0423_add_broadcast_provider_message_status
+Revises: 0422_add_publish_progress_table
+Create Date: 2026-04-16 12:27:04.628384
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0423_add_broadcast_provider_message_status"
+down_revision = "0422_add_publish_progress_table"
+
+
+def upgrade():
+    op.create_table(
+        "broadcast_provider_message_status",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("broadcast_provider_message_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "technical-failure",
+                "sending",
+                "returned-ack",
+                "returned-error",
+                name="broadcast_provider_message_status_types",
+            ),
+            nullable=False,
+        ),
+        sa.Column("error_detail", postgresql.JSONB(none_as_null=True, astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["broadcast_provider_message_id"],
+            ["broadcast_provider_message.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # In the 'old' world broadcast_provider_message has a status that gets overwritten
+    # We'll use its created_at date to create a pending status row, and then it's updated_at
+    # to create a relevant status row of what it is now.
+    op.execute(
+        """
+        INSERT INTO broadcast_provider_message_status
+            (broadcast_provider_message_id, status, created_at)
+        SELECT gen_random_uuid(), id, 'pending', created_at
+        FROM broadcast_provider_message
+    """
+    )
+    op.execute(
+        """
+        INSERT INTO broadcast_provider_message_status
+            (broadcast_provider_message_id, status, updated_at)
+        SELECT gen_random_uuid(), id, status, created_at
+        FROM broadcast_provider_message
+    """
+    )
+
+    op.drop_table("broadcast_provider_message_status_type")
+    op.drop_column("broadcast_provider_message", "updated_at")
+    op.drop_column("broadcast_provider_message", "status")
+
+
+def downgrade():
+    op.add_column("broadcast_provider_message", sa.Column("status", sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.add_column(
+        "broadcast_provider_message",
+        sa.Column("updated_at", postgresql.TIMESTAMP(), autoincrement=False, nullable=True),
+    )
+
+    op.execute("UPDATE broadcast_provider_message SET updated_at = created_at")
+    # Get the latest status and use that to backfill the old column
+    op.execute(
+        """
+            UPDATE broadcast_provider_message bpm
+            SET status = s.status
+            FROM (
+                SELECT DISTINCT ON (broadcast_provider_message_id)
+                    broadcast_provider_message_id,
+                    status
+                FROM source_table
+                ORDER BY broadcast_provider_message_id, created_at DESC
+            ) s
+            WHERE bpm.id = s.broadcast_provider_message_id;
+    """
+    )
+
+    op.drop_table("broadcast_provider_message_status")
+
+    # This table was never used for anything, so no need to put data in it...
+    op.create_table(
+        "broadcast_provider_message_status_type",
+        sa.Column("name", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("name"),
+    )

--- a/migrations/versions/0423_provider_message_status.py
+++ b/migrations/versions/0423_provider_message_status.py
@@ -49,23 +49,19 @@ def upgrade():
     # We'll use its created_at date to create a sending status row, and then it's updated_at
     # to create a relevant status row of what it is now.
     # (For messages that failed, they'll have only a sending with a null updated_at)
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO broadcast_provider_message_status
             (broadcast_provider_message_id, status, created_at)
         SELECT id, 'sending', created_at
         FROM broadcast_provider_message
-    """
-    )
-    op.execute(
-        """
+    """)
+    op.execute("""
         INSERT INTO broadcast_provider_message_status
             (broadcast_provider_message_id, status, created_at)
         SELECT id, status::broadcast_provider_message_status_types, updated_at
         FROM broadcast_provider_message
         WHERE updated_at IS NOT NULL
-    """
-    )
+    """)
 
     op.drop_table("broadcast_provider_message_status_type")
     op.drop_column("broadcast_provider_message", "updated_at")
@@ -81,8 +77,7 @@ def downgrade():
 
     op.execute("UPDATE broadcast_provider_message SET updated_at = created_at")
     # Get the latest status and use that to backfill the old column
-    op.execute(
-        """
+    op.execute("""
             UPDATE broadcast_provider_message bpm
             SET status = s.status::varchar
             FROM (
@@ -93,8 +88,7 @@ def downgrade():
                 ORDER BY broadcast_provider_message_id, id DESC
             ) s
             WHERE bpm.id = s.broadcast_provider_message_id;
-    """
-    )
+    """)
 
     op.drop_table("broadcast_provider_message_status")
     op.execute("drop sequence broadcast_provider_message_status_seq")

--- a/migrations/versions/0423_provider_message_status.py
+++ b/migrations/versions/0423_provider_message_status.py
@@ -62,6 +62,7 @@ def upgrade():
             (broadcast_provider_message_id, status, created_at)
         SELECT id, status::broadcast_provider_message_status_types, updated_at
         FROM broadcast_provider_message
+        WHERE updated_at IS NOT NULL
     """
     )
 

--- a/migrations/versions/0423_provider_message_status.py
+++ b/migrations/versions/0423_provider_message_status.py
@@ -46,8 +46,9 @@ def upgrade():
     )
 
     # In the 'old' world broadcast_provider_message has a status that gets overwritten
-    # We'll use its created_at date to create a pending status row, and then it's updated_at
+    # We'll use its created_at date to create a sending status row, and then it's updated_at
     # to create a relevant status row of what it is now.
+    # (For messages that failed, they'll have only a sending with a null updated_at)
     op.execute(
         """
         INSERT INTO broadcast_provider_message_status

--- a/migrations/versions/0423_provider_message_status.py
+++ b/migrations/versions/0423_provider_message_status.py
@@ -89,7 +89,7 @@ def downgrade():
                     broadcast_provider_message_id,
                     status
                 FROM broadcast_provider_message_status
-                ORDER BY broadcast_provider_message_id, created_at DESC
+                ORDER BY broadcast_provider_message_id, id DESC
             ) s
             WHERE bpm.id = s.broadcast_provider_message_id;
     """

--- a/migrations/versions/0423_provider_message_status.py
+++ b/migrations/versions/0423_provider_message_status.py
@@ -97,6 +97,7 @@ def downgrade():
 
     op.drop_table("broadcast_provider_message_status")
     op.execute("drop sequence broadcast_provider_message_status_seq")
+    op.execute("drop type broadcast_provider_message_status_types")
 
     # This table was never used for anything, so no need to put data in it...
     op.create_table(

--- a/migrations/versions/0423_provider_message_status.py
+++ b/migrations/versions/0423_provider_message_status.py
@@ -15,9 +15,15 @@ down_revision = "0422_add_publish_progress_table"
 
 
 def upgrade():
+    op.execute("create sequence broadcast_provider_message_status_seq")
     op.create_table(
         "broadcast_provider_message_status",
-        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "id",
+            sa.Integer(),
+            server_default=sa.text("nextval('broadcast_provider_message_status_seq')"),
+            nullable=False,
+        ),
         sa.Column("broadcast_provider_message_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column(
@@ -89,6 +95,7 @@ def downgrade():
     )
 
     op.drop_table("broadcast_provider_message_status")
+    op.execute("drop sequence broadcast_provider_message_status_seq")
 
     # This table was never used for anything, so no need to put data in it...
     op.create_table(

--- a/migrations/versions/0423_provider_message_status.py
+++ b/migrations/versions/0423_provider_message_status.py
@@ -1,6 +1,6 @@
 """
 
-Revision ID: 0423_add_broadcast_provider_message_status
+Revision ID: 0423_provider_message_status
 Revises: 0422_add_publish_progress_table
 Create Date: 2026-04-16 12:27:04.628384
 
@@ -10,7 +10,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-revision = "0423_add_broadcast_provider_message_status"
+revision = "0423_provider_message_status"
 down_revision = "0422_add_publish_progress_table"
 
 
@@ -46,15 +46,15 @@ def upgrade():
         """
         INSERT INTO broadcast_provider_message_status
             (broadcast_provider_message_id, status, created_at)
-        SELECT gen_random_uuid(), id, 'pending', created_at
+        SELECT id, 'sending', created_at
         FROM broadcast_provider_message
     """
     )
     op.execute(
         """
         INSERT INTO broadcast_provider_message_status
-            (broadcast_provider_message_id, status, updated_at)
-        SELECT gen_random_uuid(), id, status, created_at
+            (broadcast_provider_message_id, status, created_at)
+        SELECT id, status::broadcast_provider_message_status_types, updated_at
         FROM broadcast_provider_message
     """
     )
@@ -76,12 +76,12 @@ def downgrade():
     op.execute(
         """
             UPDATE broadcast_provider_message bpm
-            SET status = s.status
+            SET status = s.status::varchar
             FROM (
                 SELECT DISTINCT ON (broadcast_provider_message_id)
                     broadcast_provider_message_id,
                     status
-                FROM source_table
+                FROM broadcast_provider_message_status
                 ORDER BY broadcast_provider_message_id, created_at DESC
             ) s
             WHERE bpm.id = s.broadcast_provider_message_id;

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -16,9 +16,12 @@ from app.celery.broadcast_message_tasks import (
 from app.clients.cbc_proxy import CBCProxyRetryableException
 from app.dao.broadcast_service_dao import set_service_broadcast_providers
 from app.models import (
+    BROADCAST_PROVIDER_STATUS_ACK,
+    BROADCAST_PROVIDER_STATUS_ERR,
+    BROADCAST_PROVIDER_STATUS_SENDING,
+    BROADCAST_PROVIDER_STATUS_TECHNICAL_FAILURE,
     BROADCAST_TYPE,
     BroadcastEventMessageType,
-    BroadcastProviderMessageStatus,
     BroadcastStatusType,
 )
 from tests.app.db import (
@@ -154,7 +157,10 @@ def test_send_broadcast_provider_message_sends_data_correctly(
     send_broadcast_provider_message(provider=provider, broadcast_event_id=str(event.id))
 
     broadcast_provider_message = event.get_provider_message(provider)
-    assert broadcast_provider_message.status == BroadcastProviderMessageStatus.ACK
+    assert len(broadcast_provider_message.statuses) == 2
+    assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
+    assert broadcast_provider_message.statuses[1].status == BROADCAST_PROVIDER_STATUS_ACK
+    assert broadcast_provider_message.get_latest_status_entry().status == BROADCAST_PROVIDER_STATUS_ACK
 
     mock_create_broadcast.assert_called_once_with(
         identifier=str(broadcast_provider_message.id),
@@ -244,9 +250,13 @@ def test_send_broadcast_provider_message_works_if_we_retried_previously(mocker, 
     event = create_broadcast_event(broadcast_message)
 
     # an existing provider message already exists, and previously failed
-    create_broadcast_provider_message(
-        broadcast_event=event, provider="ee", status=BroadcastProviderMessageStatus.SENDING
-    )
+    create_broadcast_provider_message(broadcast_event=event, provider="ee", status=BROADCAST_PROVIDER_STATUS_SENDING)
+
+    broadcast_provider_message = event.get_provider_message("ee")
+
+    assert len(broadcast_provider_message.statuses) == 1
+    assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
+    assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[0]
 
     mock_create_broadcast = mocker.patch(
         "app.clients.cbc_proxy.CBCProxyEE.create_and_send_broadcast",
@@ -259,8 +269,11 @@ def test_send_broadcast_provider_message_works_if_we_retried_previously(mocker, 
 
     broadcast_provider_message = event.get_provider_message("ee")
 
-    assert broadcast_provider_message.status == BroadcastProviderMessageStatus.ACK
-    assert broadcast_provider_message.updated_at is not None
+    assert len(broadcast_provider_message.statuses) == 2
+    assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
+    assert broadcast_provider_message.statuses[0].created_at is not None
+    assert broadcast_provider_message.statuses[1].status == BROADCAST_PROVIDER_STATUS_ACK
+    assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
     mock_create_broadcast.assert_called_once_with(
         identifier=str(broadcast_provider_message.id),
@@ -348,7 +361,8 @@ def test_send_broadcast_provider_message_sends_update_with_references(
     )
 
     alert_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.ALERT)
-    create_broadcast_provider_message(alert_event, provider, status=BroadcastProviderMessageStatus.ACK)
+    create_broadcast_provider_message(alert_event, provider, status=BROADCAST_PROVIDER_STATUS_ACK)
+
     update_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.UPDATE)
 
     mock_update_broadcast = mocker.patch(
@@ -358,7 +372,11 @@ def test_send_broadcast_provider_message_sends_update_with_references(
     send_broadcast_provider_message(provider=provider, broadcast_event_id=str(update_event.id))
 
     broadcast_provider_message = update_event.get_provider_message(provider)
-    assert broadcast_provider_message.status == BroadcastProviderMessageStatus.ACK
+
+    assert len(broadcast_provider_message.statuses) == 2
+    assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
+    assert broadcast_provider_message.statuses[1].status == BROADCAST_PROVIDER_STATUS_ACK
+    assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
     mock_update_broadcast.assert_called_once_with(
         identifier=str(broadcast_provider_message.id),
@@ -406,8 +424,8 @@ def test_send_broadcast_provider_message_sends_cancel_with_references(
     update_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.UPDATE)
     cancel_event = create_broadcast_event(broadcast_message, message_type=BroadcastEventMessageType.CANCEL)
 
-    create_broadcast_provider_message(alert_event, provider, status=BroadcastProviderMessageStatus.ACK)
-    create_broadcast_provider_message(update_event, provider, status=BroadcastProviderMessageStatus.ACK)
+    create_broadcast_provider_message(alert_event, provider, status=BROADCAST_PROVIDER_STATUS_ACK)
+    create_broadcast_provider_message(update_event, provider, status=BROADCAST_PROVIDER_STATUS_ACK)
 
     mock_cancel_broadcast = mocker.patch(
         f"app.clients.cbc_proxy.CBCProxy{provider_capitalised}.cancel_broadcast",
@@ -416,7 +434,10 @@ def test_send_broadcast_provider_message_sends_cancel_with_references(
     send_broadcast_provider_message(provider=provider, broadcast_event_id=str(cancel_event.id))
 
     broadcast_provider_message = cancel_event.get_provider_message(provider)
-    assert broadcast_provider_message.status == BroadcastProviderMessageStatus.ACK
+    assert len(broadcast_provider_message.statuses) == 2
+    assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
+    assert broadcast_provider_message.statuses[1].status == BROADCAST_PROVIDER_STATUS_ACK
+    assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
     mock_cancel_broadcast.assert_called_once_with(
         identifier=str(broadcast_provider_message.id),
@@ -485,7 +506,9 @@ def test_send_broadcast_provider_message_errors(mocker, sample_broadcast_service
     )
     mock_retry.assert_called_once_with(exc=mock_create_broadcast.side_effect, countdown=ANY)
     broadcast_provider_message = event.get_provider_message(provider)
-    assert broadcast_provider_message.status == BroadcastProviderMessageStatus.SENDING
+    assert len(broadcast_provider_message.statuses) == 1
+    assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
+    assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[0]
 
 
 @pytest.mark.parametrize(
@@ -557,9 +580,9 @@ def test_send_broadcast_provider_message_raises_if_older_event_still_sending(sam
         sent_at=datetime(2021, 1, 1, 7, 0),
     )
 
-    create_broadcast_provider_message(past_succesful_event, provider="ee", status=BroadcastProviderMessageStatus.ACK)
+    create_broadcast_provider_message(past_succesful_event, provider="ee", status=BROADCAST_PROVIDER_STATUS_ACK)
     create_broadcast_provider_message(
-        past_still_sending_event, provider="ee", status=BroadcastProviderMessageStatus.SENDING
+        past_still_sending_event, provider="ee", status=BROADCAST_PROVIDER_STATUS_SENDING
     )  # noqa
 
     # we havent sent the previous update yet - it's still in sending - so don't try and send this one.
@@ -594,7 +617,7 @@ def test_send_broadcast_provider_message_raises_if_older_event_hasnt_started_sen
     )
 
     # no provider message for past_still_sending_event
-    create_broadcast_provider_message(past_succesful_event, provider="ee", status=BroadcastProviderMessageStatus.ACK)
+    create_broadcast_provider_message(past_succesful_event, provider="ee", status=BROADCAST_PROVIDER_STATUS_ACK)
 
     # we shouldn't send the update now, because a previous event is still stuck in sending
     with pytest.raises(BroadcastIntegrityError) as exc:
@@ -629,9 +652,9 @@ def test_check_event_makes_sense_in_sequence_doesnt_raise_if_newer_event_not_ack
 @pytest.mark.parametrize(
     "existing_message_status",
     [
-        BroadcastProviderMessageStatus.ACK,
-        BroadcastProviderMessageStatus.ERR,
-        BroadcastProviderMessageStatus.TECHNICAL_FAILURE,
+        BROADCAST_PROVIDER_STATUS_ACK,
+        BROADCAST_PROVIDER_STATUS_ERR,
+        BROADCAST_PROVIDER_STATUS_TECHNICAL_FAILURE,
     ],
 )
 def test_send_broadcast_provider_message_raises_if_current_event_already_has_provider_message_not_in_sending(

--- a/tests/app/celery/test_broadcast_message_tasks.py
+++ b/tests/app/celery/test_broadcast_message_tasks.py
@@ -459,7 +459,9 @@ def test_send_broadcast_provider_message_sends_cancel_with_references(
         ["vodafone", "Vodafone"],
     ],
 )
-def test_send_broadcast_provider_message_errors(mocker, sample_broadcast_service, provider, provider_capitalised):
+def test_send_broadcast_provider_message_error_statuses_are_saved(
+    mocker, sample_broadcast_service, provider, provider_capitalised
+):
     template = create_template(sample_broadcast_service, BROADCAST_TYPE)
 
     broadcast_message = create_broadcast_message(
@@ -506,9 +508,12 @@ def test_send_broadcast_provider_message_errors(mocker, sample_broadcast_service
     )
     mock_retry.assert_called_once_with(exc=mock_create_broadcast.side_effect, countdown=ANY)
     broadcast_provider_message = event.get_provider_message(provider)
-    assert len(broadcast_provider_message.statuses) == 1
+
+    assert len(broadcast_provider_message.statuses) == 2
     assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
-    assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[0]
+    assert broadcast_provider_message.statuses[1].status == BROADCAST_PROVIDER_STATUS_ERR
+    assert broadcast_provider_message.statuses[1].error_detail == {"exception": "CBCProxyRetryableException('oh no')"}
+    assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
 
 @pytest.mark.parametrize(

--- a/tests/app/dao/test_broadcast_message_dao.py
+++ b/tests/app/dao/test_broadcast_message_dao.py
@@ -83,10 +83,10 @@ def test_create_broadcast_provider_message_creates_in_correct_state(sample_broad
 
     broadcast_provider_message = create_broadcast_provider_message(broadcast_event, "fake-provider")
 
-    assert broadcast_provider_message.status == "sending"
+    assert len(broadcast_provider_message.statuses) == 1
+    assert broadcast_provider_message.get_latest_status_entry().status == "sending"
     assert broadcast_provider_message.broadcast_event_id == broadcast_event.id
     assert broadcast_provider_message.created_at is not None
-    assert broadcast_provider_message.updated_at is None
 
 
 def test_dao_get_all_broadcast_messages(sample_broadcast_service):

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -27,6 +27,7 @@ from app.models import (
     BroadcastProvider,
     BroadcastProviderMessage,
     BroadcastProviderMessageNumber,
+    BroadcastProviderMessageStatus,
     BroadcastStatusType,
     Domain,
     FailedLogin,
@@ -394,12 +395,14 @@ def create_broadcast_event(
 
 
 def create_broadcast_provider_message(broadcast_event, provider, status="sending"):
+    broadcast_provider_message_status = BroadcastProviderMessageStatus(status=status)
+
     broadcast_provider_message_id = uuid.uuid4()
     provider_message = BroadcastProviderMessage(
         id=broadcast_provider_message_id,
         broadcast_event=broadcast_event,
         provider=provider,
-        status=status,
+        statuses=[broadcast_provider_message_status],
     )
     db.session.add(provider_message)
     db.session.commit()


### PR DESCRIPTION
In the current world we have a row per MNO in `broadcast_provider_message` containing a status which gets overwritten. This PR now changes this to have a new table, with each row representing a status at that point in time, allowing us to infer timings and errors throughout sending a message to a provider.

This hopefully will be later surfaced in the UI.

Additionally we now record failures - while the status(es) for this existed it turns out we never used them? The new row has an `error_detail` column which is free-form, but at this stage it's unclear what kind of exceptions we might get (and as of writing they're likely wrapped in a Retryable exception which could be impacted by Dramatiq if that lands).

I've created a suitable migration but double check the SQL! It seems to execute locally.