### PR TITLE
EAS-2828 CBC Route Advisor

### DIFF
--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -166,7 +166,8 @@ class CBCProxyClientBase(ABC):
             )
 
         mno = self.primary_lambda.split("-", 1)[0]
-        preferred = dao_get_route_for_mno(mno)
+        route = dao_get_route_for_mno(mno)
+        preferred = (route.proxy, route.target)
 
         if preferred:
             # Move the preferred route to the top of the list
@@ -446,12 +447,12 @@ def _update_route_advisor(lambda_name, cbc_target, result):
 
     if result:
         mno = lambda_name.split("-", 1)[0]
-        validity_interval = datetime.datetime.now(timezone.utc) - timedelta(seconds=30)
+        validity_interval = datetime.now(timezone.utc) - timedelta(seconds=30)
         current_route = dao_get_route_for_mno(mno)
 
         # If the route advisor has not been verified within the last 30 seconds, assume
         # the current successful route is the latest best known route
-        if current_route.verified_at < validity_interval:
+        if current_route.updated_at < validity_interval:
             current_app.logger.info(f"Updating route advisor for {mno}: {lambda_name} | {cbc_target}")
             current_app.logger.info(
                 f"Updating route advisor for {mno}",

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -167,10 +167,8 @@ class CBCProxyClientBase(ABC):
 
         mno = self.primary_lambda.split("-", 1)[0]
         route = dao_get_route_for_mno(mno)
-        preferred = (route.proxy, route.target)
-
-        if preferred:
-            # Move the preferred route to the top of the list
+        if route:
+            preferred = (route.proxy, route.target)
             routes.remove(preferred)
             routes.insert(0, preferred)
 
@@ -452,7 +450,7 @@ def _update_route_advisor(lambda_name, cbc_target, result):
 
         # If the route advisor has not been verified within the last 30 seconds, assume
         # the current successful route is the latest best known route
-        if current_route.updated_at < validity_interval:
+        if current_route is None or current_route.updated_at < validity_interval:
             current_app.logger.info(f"Updating route advisor for {mno}: {lambda_name} | {cbc_target}")
             current_app.logger.info(
                 f"Updating route advisor for {mno}",

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
 
 import boto3
 import botocore
@@ -148,30 +149,34 @@ class CBCProxyClientBase(ABC):
         pass
 
     def _invoke_lambdas_with_routing(self, payload):
-        payload["cbc_target"] = self.CBC_A
-        result = self._invoke_lambda(self.primary_lambda, payload, self.CBC_A)
-        if result:
-            return True
+        # Import here so that app/__init__.py has finished executing create_app,
+        # so app.db exists and has been imported by app.dao.__init__
+        from app.dao.route_advisor_dao import dao_get_route_for_mno
 
-        payload["cbc_target"] = self.CBC_B
-        result = self._invoke_lambda(self.primary_lambda, payload, self.CBC_B)
-        if result:
-            return True
+        routes = [
+            (self.primary_lambda, self.CBC_A),
+            (self.primary_lambda, self.CBC_B),
+        ]
+        if self.secondary_lambda:
+            routes.extend(
+                [
+                    (self.secondary_lambda, self.CBC_A),
+                    (self.secondary_lambda, self.CBC_B),
+                ]
+            )
 
-        if not self.secondary_lambda:
-            error_message = f"{self.primary_lambda} failed and no secondary lambda defined"
-            current_app.logger.info(error_message, extra={"python_module": __name__})
-            raise CBCProxyRetryableException(error_message)
+        mno = self.primary_lambda.split("-", 1)[0]
+        preferred = dao_get_route_for_mno(mno)
 
-        payload["cbc_target"] = self.CBC_A
-        result = self._invoke_lambda(self.secondary_lambda, payload, self.CBC_A)
-        if result:
-            return True
+        if preferred:
+            # Move the preferred route to the top of the list
+            routes.remove(preferred)
+            routes.insert(0, preferred)
 
-        payload["cbc_target"] = self.CBC_B
-        result = self._invoke_lambda(self.secondary_lambda, payload, self.CBC_B)
-        if result:
-            return True
+        for route in routes:
+            result = self._invoke_lambda(route[0], payload, route[1])
+            if result:
+                return True
 
         error_message = f"{self.primary_lambda} and {self.secondary_lambda} lambdas failed"
         current_app.logger.info(error_message, extra={"python_module": __name__})
@@ -284,7 +289,8 @@ class CBCProxyOne2ManyClient(CBCProxyClientBase):
             "cbc_target": cbc_target,
         }
 
-        self._invoke_lambda(lambda_name=lambda_name, payload=payload, cbc_target=cbc_target)
+        result = self._invoke_lambda(lambda_name=lambda_name, payload=payload, cbc_target=cbc_target)
+        _update_route_advisor(lambda_name, cbc_target, result)
 
     def create_and_send_broadcast(
         self, identifier, headline, description, areas, sent, expires, channel, message_number=None
@@ -376,7 +382,8 @@ class CBCProxyVodafone(CBCProxyClientBase):
             "cbc_target": cbc_target,
         }
 
-        self._invoke_lambda(lambda_name=lambda_name, payload=payload, cbc_target=cbc_target)
+        result = self._invoke_lambda(lambda_name=lambda_name, payload=payload, cbc_target=cbc_target)
+        _update_route_advisor(lambda_name, cbc_target, result)
 
     def create_and_send_broadcast(
         self, identifier, message_number, headline, description, areas, sent, expires, channel
@@ -427,3 +434,31 @@ class CBCProxyVodafone(CBCProxyClientBase):
         message_number=None,
     ):
         pass
+
+
+def _update_route_advisor(lambda_name, cbc_target, result):
+    # Import here so that app/__init__.py has finished executing create_app,
+    # so app.db exists and has been imported by app.dao.__init__
+    from app.dao.route_advisor_dao import (
+        dao_get_route_for_mno,
+        dao_set_route_for_mno,
+    )
+
+    if result:
+        mno = lambda_name.split("-", 1)[0]
+        validity_interval = datetime.datetime.now(timezone.utc) - timedelta(seconds=30)
+        current_route = dao_get_route_for_mno(mno)
+
+        # If the route advisor has not been verified within the last 30 seconds, assume
+        # the current successful route is the latest best known route
+        if current_route.verified_at < validity_interval:
+            current_app.logger.info(f"Updating route advisor for {mno}: {lambda_name} | {cbc_target}")
+            current_app.logger.info(
+                f"Updating route advisor for {mno}",
+                extra={
+                    "proxy_lambda": lambda_name,
+                    "cbc_target": cbc_target,
+                    "python_module": __name__,
+                },
+            )
+            dao_set_route_for_mno(mno, lambda_name, cbc_target)

--- a/app/dao/route_advisor_dao.py
+++ b/app/dao/route_advisor_dao.py
@@ -1,13 +1,26 @@
 from datetime import datetime, timezone
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
 from app import db
 from app.models import RouteAdvisor
 
 
 def dao_set_route_for_mno(mno, proxy, target):
-    db.session.query(RouteAdvisor).filter_by(mno=mno).update(
-        {"proxy": proxy, "target": target, "updated_at": datetime.now(timezone.utc)}
+    sql = (
+        pg_insert(RouteAdvisor)
+        .values(
+            mno=mno,
+            proxy=proxy,
+            target=target,
+            updated_at=datetime.now(timezone.utc),
+        )
+        .on_conflict_do_update(
+            index_elements=["mno"],
+            set_={"proxy": proxy, "target": target, "updated_at": datetime.now(timezone.utc)},
+        )
     )
+    db.session.execute(sql)
     db.session.commit()
 
 

--- a/app/dao/route_advisor_dao.py
+++ b/app/dao/route_advisor_dao.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from app import db
+from app.models import RouteAdvisor
+
+
+def dao_set_route_for_mno(mno, proxy, target):
+    db.session.query(RouteAdvisor).filter_by(mno=mno).update(
+        {"proxy": proxy, "target": target, "validated_at": datetime.now(timezone.utc)}
+    )
+    db.session.commit()
+
+
+def dao_get_route_for_mno(mno):
+    route = RouteAdvisor.query.filter_by(mno=mno).first()
+    return (route.proxy, route.target) if route else (None, None)

--- a/app/dao/route_advisor_dao.py
+++ b/app/dao/route_advisor_dao.py
@@ -6,11 +6,10 @@ from app.models import RouteAdvisor
 
 def dao_set_route_for_mno(mno, proxy, target):
     db.session.query(RouteAdvisor).filter_by(mno=mno).update(
-        {"proxy": proxy, "target": target, "validated_at": datetime.now(timezone.utc)}
+        {"proxy": proxy, "target": target, "updated_at": datetime.now(timezone.utc)}
     )
     db.session.commit()
 
 
 def dao_get_route_for_mno(mno):
-    route = RouteAdvisor.query.filter_by(mno=mno).first()
-    return (route.proxy, route.target) if route else (None, None)
+    return RouteAdvisor.query.filter_by(mno=mno).first()

--- a/app/models.py
+++ b/app/models.py
@@ -1430,12 +1430,12 @@ class RouteAdvisor(db.Model):
     mno = db.Column(db.String(255), primary_key=True)
     proxy = db.Column(db.String, nullable=False)
     target = db.Column(db.String, nullable=False)
-    validated_at = db.Column(db.DateTime, nullable=False, default=utc_now())
+    updated_at = db.Column(db.DateTime(timezone=True), nullable=False, default=utc_now())
 
     def serialize(self):
         return {
             "mno": self.mno,
             "proxy": self.proxy,
             "target": self.target,
-            "validated_at": self.validated_at,
+            "updated_at": self.updated_at,
         }

--- a/app/models.py
+++ b/app/models.py
@@ -1418,3 +1418,24 @@ class PublishTaskProgress(db.Model):
             "last_activity_at": self.last_activity_at,
             "finished_at": self.finished_at,
         }
+
+
+class RouteAdvisor(db.Model):
+    """
+    This table is used to store latest known live routes between our infrastructure and CBCs.
+    """
+
+    __tablename__ = "route_advisor"
+
+    mno = db.Column(db.String(255), primary_key=True)
+    proxy = db.Column(db.String, nullable=False)
+    target = db.Column(db.String, nullable=False)
+    validated_at = db.Column(db.DateTime, nullable=False, default=utc_now())
+
+    def serialize(self):
+        return {
+            "mno": self.mno,
+            "proxy": self.proxy,
+            "target": self.target,
+            "validated_at": self.validated_at,
+        }

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   api:
     build:

--- a/migrations/versions/0423_route_advisor_table.py
+++ b/migrations/versions/0423_route_advisor_table.py
@@ -1,0 +1,31 @@
+"""
+
+Revision ID: 0423_route_advisor_table
+Revises: 0422_add_publish_progress_table
+Create Date: 2026-04-23 13:45:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0423_route_advisor_table"
+down_revision = "0422_add_publish_progress_table"
+
+PROVIDER_TYPES = ("ee", "o2", "three", "vodafone")
+
+
+def upgrade():
+    op.create_table(
+        "route_advisor",
+        sa.Column("mno", sa.String(length=255), nullable=False),
+        sa.PrimaryKeyConstraint("mno"),
+        sa.Column("proxy", sa.String(length=255), nullable=True),
+        sa.Column("target", sa.String(length=255), nullable=True)
+    )
+    for provider in PROVIDER_TYPES:
+        op.execute(f"INSERT INTO route_advisor VALUES ('{provider}', 'primary', 'a')")
+
+
+def downgrade():
+    op.drop_table("route_advisor")

--- a/migrations/versions/0423_route_advisor_table.py
+++ b/migrations/versions/0423_route_advisor_table.py
@@ -23,7 +23,7 @@ def upgrade():
         sa.PrimaryKeyConstraint("mno"),
         sa.Column("proxy", sa.String(length=255), nullable=True),
         sa.Column("target", sa.String(length=255), nullable=True),
-        sa.Column("validated_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
     )
     for provider in PROVIDER_TYPES:
         op.execute(

--- a/migrations/versions/0423_route_advisor_table.py
+++ b/migrations/versions/0423_route_advisor_table.py
@@ -8,6 +8,7 @@ Create Date: 2026-04-23 13:45:00
 
 import sqlalchemy as sa
 from alembic import op
+from datetime import datetime, timezone
 
 revision = "0423_route_advisor_table"
 down_revision = "0422_add_publish_progress_table"
@@ -21,10 +22,14 @@ def upgrade():
         sa.Column("mno", sa.String(length=255), nullable=False),
         sa.PrimaryKeyConstraint("mno"),
         sa.Column("proxy", sa.String(length=255), nullable=True),
-        sa.Column("target", sa.String(length=255), nullable=True)
+        sa.Column("target", sa.String(length=255), nullable=True),
+        sa.Column("validated_at", sa.DateTime, nullable=False),
     )
     for provider in PROVIDER_TYPES:
-        op.execute(f"INSERT INTO route_advisor VALUES ('{provider}', 'primary', 'a')")
+        op.execute(
+            "INSERT INTO route_advisor "
+            f"VALUES ('{provider}', '{provider}-1-proxy', 'cbc_a', '{datetime.now(timezone.utc)}')"
+        )
 
 
 def downgrade():

--- a/migrations/versions/0424_route_advisor_table.py
+++ b/migrations/versions/0424_route_advisor_table.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0423_route_advisor_table
-Revises: 0422_add_publish_progress_table
+Revision ID: 0424_route_advisor_table
+Revises: 0423_provider_message_status
 Create Date: 2026-04-23 13:45:00
 
 """
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 from datetime import datetime, timezone
 
-revision = "0423_route_advisor_table"
-down_revision = "0422_add_publish_progress_table"
+revision = "0424_route_advisor_table"
+down_revision = "0423_provider_message_status"
 
 PROVIDER_TYPES = ("ee", "o2", "three", "vodafone")
 

--- a/migrations/versions/0424_route_advisor_table.py
+++ b/migrations/versions/0424_route_advisor_table.py
@@ -8,12 +8,9 @@ Create Date: 2026-04-23 13:45:00
 
 import sqlalchemy as sa
 from alembic import op
-from datetime import datetime, timezone
 
 revision = "0424_route_advisor_table"
 down_revision = "0423_provider_message_status"
-
-PROVIDER_TYPES = ("ee", "o2", "three", "vodafone")
 
 
 def upgrade():
@@ -25,11 +22,6 @@ def upgrade():
         sa.Column("target", sa.String(length=255), nullable=True),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
     )
-    for provider in PROVIDER_TYPES:
-        op.execute(
-            "INSERT INTO route_advisor "
-            f"VALUES ('{provider}', '{provider}-1-proxy', 'cbc_a', '{datetime.now(timezone.utc)}')"
-        )
 
 
 def downgrade():

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -74,7 +74,7 @@ def cbc_proxy_vodafone(cbc_proxy_client):
         ("vodafone", CBCProxyVodafone),
     ],
 )
-def test_cbc_proxy_client_returns_correct_client(provider_name, expected_provider_class):
+def test_cbc_proxy_client_returns_correct_client(notify_db_session, provider_name, expected_provider_class):
     mock_lambda = Mock()
     cbc_proxy_client = CBCProxyClient()
     cbc_proxy_client._lambda_client = mock_lambda
@@ -115,6 +115,7 @@ def test_cbc_proxy_send_link_test(mocker, cbc_proxy_ee):
 )
 @pytest.mark.parametrize("cbc", ["ee", "three", "o2"])
 def test_cbc_proxy_one_2_many_create_and_send_invokes_function(
+    notify_db_session,
     mocker,
     cbc_proxy_client,
     description,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ def _clean_database(_db):
             "service_callback_type",
             "broadcast_channel_types",
             "broadcast_provider_types",
+            "route_advisor",
         ]:
             _db.engine.execute(tbl.delete())
     _db.session.commit()


### PR DESCRIPTION
The link tests write the lambda (primary | secondary) and CBC endpoint (cbc_a | cbc_b) of the fastest responding route to the new database table 'route_advisor'.
The broadcast method now checks this route_advisor table and preferentially picks the stored route to try first. If for some reason the stored route fails, for example if a MNO has just swapped the live/standby infrastructure, the broadcast method will continue to try the remaining routes until a successful route to the target MNO is found.