### PR TITLE
EAS-2972: Allow broadcast provider retries if in sending-error status

### DIFF
--- a/app/tasks/broadcast_message_tasks.py
+++ b/app/tasks/broadcast_message_tasks.py
@@ -57,8 +57,13 @@ def _check_event_makes_sense_in_sequence(broadcast_event: BroadcastEvent, provid
     current_provider_message: BroadcastProviderMessage | None = broadcast_event.get_provider_message(provider)
     current_provider_status = current_provider_message.get_latest_status_entry() if current_provider_message else None
 
-    # if this is the first time a task is being executed, it won't have a provider message yet
-    if current_provider_status and current_provider_status.status != BROADCAST_PROVIDER_STATUS_SENDING:
+    # If this is the first time a task is being executed, it won't have a provider message yet
+    # If the second time, then there'll should a sending status alongside another one. If it's
+    # failed we'll allow the retry.
+    if current_provider_status and current_provider_status.status not in {
+        BROADCAST_PROVIDER_STATUS_SENDING,
+        BROADCAST_PROVIDER_STATUS_ERR,
+    }:
         raise BroadcastIntegrityError(
             f"Cannot send broadcast_event {broadcast_event.id} "
             + f"to provider {provider}: "

--- a/tests/app/tasks/test_broadcast_message_tasks.py
+++ b/tests/app/tasks/test_broadcast_message_tasks.py
@@ -656,11 +656,10 @@ def test_check_event_makes_sense_in_sequence_doesnt_raise_if_newer_event_not_ack
     "existing_message_status",
     [
         BROADCAST_PROVIDER_STATUS_ACK,
-        BROADCAST_PROVIDER_STATUS_ERR,
         BROADCAST_PROVIDER_STATUS_TECHNICAL_FAILURE,
     ],
 )
-def test_send_broadcast_provider_message_raises_if_current_event_already_has_provider_message_not_in_sending(
+def test_send_broadcast_provider_message_raises_if_current_event_already_has_provider_message_final(
     sample_template, existing_message_status
 ):
     broadcast_message = create_broadcast_message(sample_template)
@@ -671,6 +670,27 @@ def test_send_broadcast_provider_message_raises_if_current_event_already_has_pro
         send_broadcast_provider_message(current_event.id, "ee")
 
     assert f"in status {existing_message_status}" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "existing_message_status",
+    [
+        BROADCAST_PROVIDER_STATUS_SENDING,
+        BROADCAST_PROVIDER_STATUS_ERR,
+    ],
+)
+def test_send_broadcast_provider_message_doesnt_raise_for_sending_or_failed_statuses(
+    mocker, sample_template, existing_message_status
+):
+    mocker.patch(
+        "app.clients.cbc_proxy.CBCProxyEE.create_and_send_broadcast",
+    )
+
+    broadcast_message = create_broadcast_message(sample_template)
+    current_event = create_broadcast_event(broadcast_message, message_type="alert")
+    create_broadcast_provider_message(current_event, provider="ee", status=existing_message_status)
+
+    send_broadcast_provider_message(current_event.id, "ee")
 
 
 def test_send_broadcast_provider_message_raises_if_service_is_suspended(


### PR DESCRIPTION
#332 brought in a subtle breakage - broadcast message tasks are no longer retried after a failure. While the message queue logic would retry it appropriately, upon the next try we assert that the status is no longer sending and throw a different (non-retryable) exception. Before then we never recorded failure statuses, ever, and thus never ran into that logic tripping...

To add some extra confusion #339 semi worked around this by only recording a failure on the last send attempt. Unfortunately in Dramatiq we don't have runtime awareness of the retry, as against SQS we let the infrastructure handle redelivery and the DLQ after x attempts, so that design can't quite work as we are.

To make matters worse there is meant to be a functional test for this scenario, but it appears to be passing sometimes when it shouldn't as the CBC doesn't seem to correctly break. It's something I want to delve into but either way we'd want the retry behaviour working.