### PR TITLE
Revert "fix/Remove `manage_setting` references and remove the check when archiving user

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -127,7 +127,7 @@ def setup_commands(application):
 @click.option("-p", "--permissions", required=True, help="Comma separated list of permissions.")
 def bulk_invite_user_to_service(file_name, service_id, user_id, auth_type, permissions):
     #  permissions
-    #  manage_users | manage_templates
+    #  manage_users | manage_templates | manage_settings
     #  Access API keys manage_api_keys
     #  platform_admin
     #  view_activity

--- a/app/dao/permissions_dao.py
+++ b/app/dao/permissions_dao.py
@@ -2,6 +2,7 @@ from app import db
 from app.dao import DAOClass
 from app.models import (
     MANAGE_API_KEYS,
+    MANAGE_SETTINGS,
     MANAGE_TEMPLATES,
     MANAGE_USERS,
     VIEW_ACTIVITY,
@@ -12,6 +13,7 @@ from app.models import (
 default_service_permissions = [
     MANAGE_USERS,
     MANAGE_TEMPLATES,
+    MANAGE_SETTINGS,
     MANAGE_API_KEYS,
     VIEW_ACTIVITY,
 ]

--- a/app/dao/users_dao.py
+++ b/app/dao/users_dao.py
@@ -175,7 +175,7 @@ def get_user_and_accounts(user_id):
 @autocommit
 def dao_archive_user(user):
     if not user_can_be_archived(user):
-        msg = "User can’t be archived - check all services the user belongs to have other active team members"
+        msg = "User can’t be removed from a service - check all services have another team member with manage_settings"
         raise InvalidRequest(msg, 400)
 
     permission_dao.remove_user_service_permissions_for_all_services(user)
@@ -206,6 +206,10 @@ def user_can_be_archived(user):
         other_active_users = [x for x in service.users if x.state == "active" and x != user]
 
         if not other_active_users:
+            return False
+
+        if not any("manage_settings" in user.get_permissions(service.id) for user in other_active_users):
+            # no-one else has manage settings
             return False
 
     return True

--- a/app/models.py
+++ b/app/models.py
@@ -746,6 +746,7 @@ class InvitedOrganisationUser(db.Model):
 # Service Permissions
 MANAGE_USERS = "manage_users"
 MANAGE_TEMPLATES = "manage_templates"
+MANAGE_SETTINGS = "manage_settings"
 MANAGE_API_KEYS = "manage_api_keys"
 PLATFORM_ADMIN = "platform_admin"
 VIEW_ACTIVITY = "view_activity"
@@ -758,6 +759,7 @@ REJECT_BROADCASTS = "reject_broadcasts"
 PERMISSION_LIST = [
     MANAGE_USERS,
     MANAGE_TEMPLATES,
+    MANAGE_SETTINGS,
     MANAGE_API_KEYS,
     PLATFORM_ADMIN,
     VIEW_ACTIVITY,

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -298,7 +298,7 @@ def sample_invited_org_user(sample_user, sample_organisation):
 @pytest.fixture(scope="function")
 def sample_user_service_permission(sample_user):
     service = create_service(user=sample_user, check_if_service_exists=True)
-    permission = "manage_templates"
+    permission = "manage_settings"
 
     data = {"user": sample_user, "service": service, "permission": permission}
     p_model = Permission.query.filter_by(user=sample_user, service=service, permission=permission).first()

--- a/tests/app/dao/test_invited_user_dao.py
+++ b/tests/app/dao/test_invited_user_dao.py
@@ -143,7 +143,7 @@ def make_invitation(user, service, age=None, email_address="test@test.com"):
         service=service,
         status="pending",
         created_at=datetime.now(timezone.utc) - (age or timedelta(hours=0)),
-        permissions="manage_templates",
+        permissions="manage_settings",
         folder_permissions=[str(uuid.uuid4())],
     )
     db.session.add(verify_code)

--- a/tests/app/dao/test_permissions_dao.py
+++ b/tests/app/dao/test_permissions_dao.py
@@ -1,15 +1,15 @@
-from app.dao.permissions_dao import default_service_permissions, permission_dao
+from app.dao.permissions_dao import permission_dao
 from tests.app.db import create_service
 
 
 def test_get_permissions_by_user_id_returns_all_permissions(sample_service):
     permissions = permission_dao.get_permissions_by_user_id(user_id=sample_service.users[0].id)
-    assert [permission.permission for permission in permissions] == default_service_permissions
-    assert len(permissions) == 4
+    assert len(permissions) == 5
     assert sorted(
         [
             "manage_users",
             "manage_templates",
+            "manage_settings",
             "manage_api_keys",
             "view_activity",
         ]
@@ -21,7 +21,6 @@ def test_get_permissions_by_user_id_returns_only_active_service(sample_user):
     inactive_service = create_service(user=sample_user, service_name="Inactive service", active=False)
 
     permissions = permission_dao.get_permissions_by_user_id(user_id=sample_user.id)
-    assert len(permissions) == 4
-    assert [permission.permission for permission in permissions] == default_service_permissions
+    assert len(permissions) == 5
     assert active_service in [i.service for i in permissions]
     assert inactive_service not in [i.service for i in permissions]

--- a/tests/app/dao/test_services_dao.py
+++ b/tests/app/dao/test_services_dao.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from app import db
 from app.dao.organisation_dao import dao_add_service_to_organisation
-from app.dao.permissions_dao import default_service_permissions
 from app.dao.service_permissions_dao import dao_remove_service_permission
 from app.dao.service_user_dao import (
     dao_get_service_user,
@@ -29,8 +28,6 @@ from app.dao.users_dao import create_user_code, save_model_user
 from app.models import (
     BROADCAST_TYPE,
     EMAIL_AUTH_TYPE,
-    MANAGE_API_KEYS,
-    MANAGE_USERS,
     ApiKey,
     InvitedUser,
     Organisation,
@@ -208,8 +205,7 @@ def test_should_remove_user_from_service(notify_db_session):
 
 
 def test_removing_a_user_from_a_service_deletes_their_permissions(sample_user, sample_service):
-    assert [permission.permission for permission in Permission.query.all()] == default_service_permissions
-    assert len(Permission.query.all()) == 4
+    assert len(Permission.query.all()) == 5
 
     dao_remove_user_from_service(sample_service, sample_user)
 
@@ -512,8 +508,7 @@ def test_add_existing_user_to_another_service_doesnot_change_old_permissions(not
     dao_create_service(service_one, user)
     assert user.id == service_one.users[0].id
     test_user_permissions = Permission.query.filter_by(service=service_one, user=user).all()
-    assert len(test_user_permissions) == 4
-    assert [permission.permission for permission in test_user_permissions] == default_service_permissions
+    assert len(test_user_permissions) == 5
 
     other_user = User(
         name="Other Test User",
@@ -527,29 +522,23 @@ def test_add_existing_user_to_another_service_doesnot_change_old_permissions(not
 
     assert other_user.id == service_two.users[0].id
     other_user_permissions = Permission.query.filter_by(service=service_two, user=other_user).all()
-    assert len(other_user_permissions) == 4
-    assert [permission.permission for permission in other_user_permissions] == default_service_permissions
+    assert len(other_user_permissions) == 5
 
     other_user_service_one_permissions = Permission.query.filter_by(service=service_one, user=other_user).all()
     assert len(other_user_service_one_permissions) == 0
 
     # adding the other_user to service_one should leave all other_user permissions on service_two intact
     permissions = []
-    for p in ["manage_users", "manage_api_keys"]:
+    for p in ["manage_users", "manage_settings", "manage_api_keys"]:
         permissions.append(Permission(permission=p))
 
     dao_add_user_to_service(service_one, other_user, permissions=permissions)
 
     other_user_service_one_permissions = Permission.query.filter_by(service=service_one, user=other_user).all()
-    assert len(other_user_service_one_permissions) == 2
-    assert [permission.permission for permission in other_user_service_one_permissions] == [
-        MANAGE_USERS,
-        MANAGE_API_KEYS,
-    ]
+    assert len(other_user_service_one_permissions) == 3
 
     other_user_service_two_permissions = Permission.query.filter_by(service=service_two, user=other_user).all()
-    assert len(other_user_service_two_permissions) == 4
-    assert [permission.permission for permission in other_user_service_two_permissions] == default_service_permissions
+    assert len(other_user_service_two_permissions) == 5
 
 
 def test_dao_fetch_active_users_for_service_returns_active_only(notify_db_session):

--- a/tests/app/dao/test_users_dao.py
+++ b/tests/app/dao/test_users_dao.py
@@ -211,14 +211,14 @@ def test_dao_archive_user(sample_user, sample_organisation, fake_uuid):
     service_1 = create_service(service_name="Service 1")
     service_1_user = create_user(email="1@test.com")
     service_1.users = [sample_user, service_1_user]
-    create_permissions(sample_user, service_1, "manage_templates")
-    create_permissions(service_1_user, service_1, "manage_templates", "view_activity")
+    create_permissions(sample_user, service_1, "manage_settings")
+    create_permissions(service_1_user, service_1, "manage_settings", "view_activity")
 
     service_2 = create_service(service_name="Service 2")
     service_2_user = create_user(email="2@test.com")
     service_2.users = [sample_user, service_2_user]
     create_permissions(sample_user, service_2, "view_activity")
-    create_permissions(service_2_user, service_2, "manage_templates")
+    create_permissions(service_2_user, service_2, "manage_settings")
 
     # make sample_user an org member
     sample_organisation.users = [sample_user]
@@ -256,16 +256,16 @@ def test_user_can_be_archived_if_they_do_not_belong_to_any_active_services(sampl
     assert user_can_be_archived(sample_user)
 
 
-def test_user_can_be_archived_if_the_service_has_other_service_members(sample_service):
+def test_user_can_be_archived_if_the_other_service_members_have_the_manage_settings_permission(sample_service):
     user_1 = create_user(email="1@test.com")
     user_2 = create_user(email="2@test.com")
     user_3 = create_user(email="3@test.com")
 
     sample_service.users = [user_1, user_2, user_3]
 
-    create_permissions(user_1, sample_service, "manage_templates")
-    create_permissions(user_2, sample_service, "manage_templates", "view_activity")
-    create_permissions(user_3, sample_service, "manage_templates", "create_broadcasts", "reject_broadcasts")
+    create_permissions(user_1, sample_service, "manage_settings")
+    create_permissions(user_2, sample_service, "manage_settings", "view_activity")
+    create_permissions(user_3, sample_service, "manage_settings", "create_broadcasts", "reject_broadcasts")
 
     assert len(sample_service.users) == 3
     assert user_can_be_archived(user_1)
@@ -289,14 +289,18 @@ def test_user_cannot_be_archived_if_they_belong_to_a_service_with_no_other_activ
     assert not user_can_be_archived(active_user)
 
 
-def test_user_cannot_be_archived_if_no_other_team_members_in_service(
+def test_user_cannot_be_archived_if_the_other_service_members_do_not_have_the_manage_setting_permission(
     sample_service,
 ):
     active_user = create_user(email="1@test.com")
+    pending_user = create_user(email="2@test.com")
+    inactive_user = create_user(email="3@test.com")
 
-    sample_service.users = [active_user]
+    sample_service.users = [active_user, pending_user, inactive_user]
 
-    create_permissions(active_user, sample_service, "manage_templates")
+    create_permissions(active_user, sample_service, "manage_settings")
+    create_permissions(pending_user, sample_service, "view_activity")
+    create_permissions(inactive_user, sample_service, "create_broadcasts", "approve_broadcasts", "reject_broadcasts")
 
-    assert len(sample_service.users) == 1
+    assert len(sample_service.users) == 3
     assert not user_can_be_archived(active_user)

--- a/tests/app/service/test_rest.py
+++ b/tests/app/service/test_rest.py
@@ -762,6 +762,7 @@ def test_add_existing_user_to_another_service_with_all_permissions(
             data = {
                 "permissions": [
                     {"permission": "manage_users"},
+                    {"permission": "manage_settings"},
                     {"permission": "manage_api_keys"},
                     {"permission": "manage_templates"},
                     {"permission": "view_activity"},
@@ -801,6 +802,7 @@ def test_add_existing_user_to_another_service_with_all_permissions(
             permissions = json_resp["data"]["permissions"][str(sample_service.id)]
             expected_permissions = [
                 "manage_users",
+                "manage_settings",
                 "manage_templates",
                 "manage_api_keys",
                 "view_activity",
@@ -873,6 +875,7 @@ def test_add_existing_user_to_another_service_with_manage_permissions(
             data = {
                 "permissions": [
                     {"permission": "manage_users"},
+                    {"permission": "manage_settings"},
                     {"permission": "manage_templates"},
                 ]
             }
@@ -898,7 +901,7 @@ def test_add_existing_user_to_another_service_with_manage_permissions(
             json_resp = resp.json
 
             permissions = json_resp["data"]["permissions"][str(sample_service.id)]
-            expected_permissions = ["manage_users", "manage_templates"]
+            expected_permissions = ["manage_users", "manage_settings", "manage_templates"]
             assert sorted(expected_permissions) == sorted(permissions)
 
 
@@ -1064,7 +1067,7 @@ def test_remove_user_from_service(client, sample_user_service_permission):
     dao_add_user_to_service(
         service,
         second_user,
-        permissions=[Permission(service_id=service.id, user_id=second_user.id, permission="manage_templates")],
+        permissions=[Permission(service_id=service.id, user_id=second_user.id, permission="manage_settings")],
     )
 
     endpoint = url_for("service.remove_user_from_service", service_id=str(service.id), user_id=str(second_user.id))
@@ -1588,7 +1591,7 @@ def test_set_training_service_as_broadcast_service_removes_user_permissions(
             )
         ],
     )
-    assert len(service_user.get_permissions(service_id=sample_training_service.id)) == 4
+    assert len(service_user.get_permissions(service_id=sample_training_service.id)) == 5
     assert len(sample_invited_user.get_permissions()) == 3
 
     admin_request.post(
@@ -1626,7 +1629,7 @@ def test_change_service_broadcast_providers_does_not_remove_user_permissions(
             )
         ],
     )
-    assert len(service_user.get_permissions(service_id=sample_service.id)) == 4
+    assert len(service_user.get_permissions(service_id=sample_service.id)) == 5
     assert len(sample_invited_user.get_permissions()) == 3
 
     admin_request.post(
@@ -1639,6 +1642,7 @@ def test_change_service_broadcast_providers_does_not_remove_user_permissions(
     assert service_user.get_permissions(service_id=sample_service.id) == [
         "manage_users",
         "manage_templates",
+        "manage_settings",
         "manage_api_keys",
         "view_activity",
     ]

--- a/tests/app/user/test_rest.py
+++ b/tests/app/user/test_rest.py
@@ -15,7 +15,7 @@ from app.dao.service_user_dao import (
 from app.dao.users_dao import get_user_by_id
 from app.models import (
     EMAIL_AUTH_TYPE,
-    MANAGE_API_KEYS,
+    MANAGE_SETTINGS,
     MANAGE_TEMPLATES,
     SMS_AUTH_TYPE,
     CommonPasswords,
@@ -337,7 +337,7 @@ def test_archive_user_when_user_cannot_be_archived(mocker, admin_request, sample
     mocker.patch("app.dao.users_dao.user_can_be_archived", return_value=False)
 
     json_resp = admin_request.post("user.archive_user", user_id=sample_user.id, _expected_status=400)
-    msg = "User can’t be archived - check all services the user belongs to have other active team members"
+    msg = "User can’t be removed from a service - check all services have another team member with manage_settings"
 
     assert json_resp["message"] == msg
 
@@ -440,18 +440,18 @@ def test_set_user_permissions(admin_request, sample_user, sample_service):
         "user.set_permissions",
         user_id=str(sample_user.id),
         service_id=str(sample_service.id),
-        _data={"permissions": [{"permission": MANAGE_TEMPLATES}]},
+        _data={"permissions": [{"permission": MANAGE_SETTINGS}]},
         _expected_status=204,
     )
 
-    permission = Permission.query.filter_by(permission=MANAGE_TEMPLATES).first()
+    permission = Permission.query.filter_by(permission=MANAGE_SETTINGS).first()
     assert permission.user == sample_user
     assert permission.service == sample_service
-    assert permission.permission == MANAGE_TEMPLATES
+    assert permission.permission == MANAGE_SETTINGS
 
 
 def test_set_user_permissions_multiple(admin_request, sample_user, sample_service):
-    data = {"permissions": [{"permission": MANAGE_API_KEYS}, {"permission": MANAGE_TEMPLATES}]}
+    data = {"permissions": [{"permission": MANAGE_SETTINGS}, {"permission": MANAGE_TEMPLATES}]}
     admin_request.post(
         "user.set_permissions",
         user_id=str(sample_user.id),
@@ -460,10 +460,10 @@ def test_set_user_permissions_multiple(admin_request, sample_user, sample_servic
         _expected_status=204,
     )
 
-    permission = Permission.query.filter_by(permission=MANAGE_API_KEYS).first()
+    permission = Permission.query.filter_by(permission=MANAGE_SETTINGS).first()
     assert permission.user == sample_user
     assert permission.service == sample_service
-    assert permission.permission == MANAGE_API_KEYS
+    assert permission.permission == MANAGE_SETTINGS
     permission = Permission.query.filter_by(permission=MANAGE_TEMPLATES).first()
     assert permission.user == sample_user
     assert permission.service == sample_service
@@ -471,7 +471,7 @@ def test_set_user_permissions_multiple(admin_request, sample_user, sample_servic
 
 
 def test_set_user_permissions_remove_old(admin_request, sample_user, sample_service):
-    data = {"permissions": [{"permission": MANAGE_API_KEYS}]}
+    data = {"permissions": [{"permission": MANAGE_SETTINGS}]}
 
     admin_request.post(
         "user.set_permissions",
@@ -483,7 +483,7 @@ def test_set_user_permissions_remove_old(admin_request, sample_user, sample_serv
 
     query = Permission.query.filter_by(user=sample_user)
     assert query.count() == 1
-    assert query.first().permission == MANAGE_API_KEYS
+    assert query.first().permission == MANAGE_SETTINGS
 
 
 def test_set_user_folder_permissions(admin_request, sample_user, sample_service):


### PR DESCRIPTION
…hen archiving user (#345)"

This reverts commit 0d7e86df994afd7528d65435c0bb0bb04c4f39e5.

Reverting due to some users still having the permission, so this will need to be deleted from `permissions` table before the work can go in - otherwise there's an error raised when the user logs in as they have permissions that no longer exist within defined permissions. The migration version will need to go in first #352 