### PR TITLE
EAS-3091 Fetch updated_at on broadcast message objects

### DIFF
--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -210,6 +210,7 @@ def dao_get_filtered_broadcast_messages():
             BroadcastMessage.areas,
             BroadcastMessage.status,
             BroadcastMessage.starts_at,
+            BroadcastMessage.updated_at,
             BroadcastMessage.finishes_at,
             BroadcastMessage.approved_at,
             BroadcastMessage.cancelled_at,

--- a/app/govuk_alerts/rest.py
+++ b/app/govuk_alerts/rest.py
@@ -30,6 +30,7 @@ def get_broadcasts():
                 "areas": broadcast.areas,
                 "status": broadcast.status,
                 "starts_at": get_dt_string_or_none(broadcast.starts_at),
+                "updated_at": get_dt_string_or_none(broadcast.updated_at),
                 "finishes_at": get_dt_string_or_none(broadcast.finishes_at),
                 "approved_at": get_dt_string_or_none(broadcast.approved_at),
                 "cancelled_at": get_dt_string_or_none(broadcast.cancelled_at),

--- a/app/tasks/stub_tasks.py
+++ b/app/tasks/stub_tasks.py
@@ -7,7 +7,7 @@ from app import dramatiq
 # dramatiq can bind an actor name and queue name in this repo.
 
 
-@dramatiq.actor(actor_name=TaskNames.PUBLISH_GOVUK_ALERTS, queue_name=QueueNames.GOVUK_ALERTS, cut_off=None)
+@dramatiq.actor(actor_name=TaskNames.PUBLISH_GOVUK_ALERTS, queue_name=QueueNames.GOVUK_ALERTS)
 def publish_govuk_alerts(*args, **kwargs):
     raise NotImplementedError(
         f"Attempted to run {TaskNames.PUBLISH_GOVUK_ALERTS} but this is the "

--- a/app/tasks/stub_tasks.py
+++ b/app/tasks/stub_tasks.py
@@ -7,7 +7,7 @@ from app import dramatiq
 # dramatiq can bind an actor name and queue name in this repo.
 
 
-@dramatiq.actor(actor_name=TaskNames.PUBLISH_GOVUK_ALERTS, queue_name=QueueNames.GOVUK_ALERTS)
+@dramatiq.actor(actor_name=TaskNames.PUBLISH_GOVUK_ALERTS, queue_name=QueueNames.GOVUK_ALERTS, cut_off=None)
 def publish_govuk_alerts(*args, **kwargs):
     raise NotImplementedError(
         f"Attempted to run {TaskNames.PUBLISH_GOVUK_ALERTS} but this is the "

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -339,7 +339,9 @@ def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
 
 
 @pytest.mark.parametrize("cbc", ["ee", "vodafone", "three", "o2"])
-def test_cbc_proxy_will_make_four_attempts_to_invoke_lambdas_if_boto_client_error(mocker, cbc_proxy_client, cbc):
+def test_cbc_proxy_will_make_four_attempts_to_invoke_lambdas_if_boto_client_error(
+    notify_db_session, mocker, cbc_proxy_client, cbc
+):
     cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     ld_client_mock = mocker.patch.object(


### PR DESCRIPTION
Serialise the 'updated_at' field for each alert - this will allow the govuk publishing task to restrict publishing to alerts that have been modified.