### PR TITLE
EAS-3065: API: Introduce new purging endpoint for test API keys

### DIFF
--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -50,3 +50,14 @@ def get_unsigned_secret(key_id):
     """
     api_key = ApiKey.query.filter_by(id=key_id, expiry_date=None).one()
     return api_key.secret
+
+
+@autocommit
+def purge_test_api_keys(service_id):
+    # Only looks for TestKey-blah, which is what the functional tests make
+    ApiKey.query.filter(ApiKey.service_id == service_id, ApiKey.name.startswith("Key-")).delete(
+        synchronize_session="fetch"
+    )
+    ApiKey.get_history_model().query.filter(ApiKey.service_id == service_id, ApiKey.name.startswith("Key-")).delete(
+        synchronize_session="fetch"
+    )

--- a/app/dao/api_key_dao.py
+++ b/app/dao/api_key_dao.py
@@ -58,6 +58,7 @@ def purge_test_api_keys(service_id):
     ApiKey.query.filter(ApiKey.service_id == service_id, ApiKey.name.startswith("Key-")).delete(
         synchronize_session="fetch"
     )
-    ApiKey.get_history_model().query.filter(ApiKey.service_id == service_id, ApiKey.name.startswith("Key-")).delete(
+    ApiKeyHistory = ApiKey.get_history_model()
+    ApiKeyHistory.query.filter(ApiKeyHistory.service_id == service_id, ApiKeyHistory.name.startswith("Key-")).delete(
         synchronize_session="fetch"
     )

--- a/app/service/rest.py
+++ b/app/service/rest.py
@@ -10,6 +10,7 @@ from app.dao.api_key_dao import (
     expire_api_key,
     get_model_api_keys,
     get_unsigned_secret,
+    purge_test_api_keys,
     save_model_api_key,
 )
 from app.dao.broadcast_service_dao import (
@@ -201,6 +202,19 @@ def get_api_keys(service_id, key_id=None):
         raise InvalidRequest(error, status_code=404)
 
     return jsonify(apiKeys=api_key_schema.dump(api_keys, many=True)), 200
+
+
+@service_blueprint.route("/<uuid:service_id>/api-key/purge", methods=["DELETE"])
+def purge_test_admin_actions_created_by(service_id):
+    if is_public_environment():
+        raise InvalidRequest("Endpoint not found", status_code=404)
+
+    try:
+        purge_test_api_keys(service_id)
+    except Exception:
+        return jsonify(result="error", message="Unable to purge test API keys"), 500
+
+    return jsonify({"message": "Successfully purged API keys"}), 200
 
 
 @service_blueprint.route("/<uuid:service_id>/users", methods=["GET"])

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -184,4 +184,4 @@ def test_dao_purge_test_api_keys(sample_service):
     assert len(keys) == 1
     assert keys[0].name == "Kept-123"
     history_keys = ApiKey.get_history_model().query.filter(ApiKey.service_id == sample_service.id).all()
-    assert len(history_keys) == 2
+    assert len(history_keys) == 1

--- a/tests/app/dao/test_api_key_dao.py
+++ b/tests/app/dao/test_api_key_dao.py
@@ -10,6 +10,7 @@ from app.dao.api_key_dao import (
     get_model_api_keys,
     get_unsigned_secret,
     get_unsigned_secrets,
+    purge_test_api_keys,
     save_model_api_key,
 )
 from app.models import ApiKey
@@ -151,3 +152,36 @@ def test_should_not_return_revoked_api_keys_older_than_7_days(sample_service, da
     all_api_keys = get_model_api_keys(service_id=sample_service.id)
 
     assert len(all_api_keys) == expected_length
+
+
+def test_dao_purge_test_api_keys(sample_service):
+    key1 = ApiKey(
+        name="Kept-123",
+        _secret="kept123",
+        service_id=sample_service.id,
+        key_type="normal",
+        created_by=sample_service.created_by,
+    )
+    key2 = ApiKey(
+        name="Key-123",
+        _secret="key123",
+        service_id=sample_service.id,
+        key_type="normal",
+        created_by=sample_service.created_by,
+    )
+
+    save_model_api_key(key1)
+    save_model_api_key(key2)
+
+    keys = get_model_api_keys(sample_service.id)
+    assert len(keys) == 2
+    history_keys = ApiKey.get_history_model().query.filter(ApiKey.service_id == sample_service.id).all()
+    assert len(history_keys) == 2
+
+    purge_test_api_keys(sample_service.id)
+
+    keys = get_model_api_keys(sample_service.id)
+    assert len(keys) == 1
+    assert keys[0].name == "Kept-123"
+    history_keys = ApiKey.get_history_model().query.filter(ApiKey.service_id == sample_service.id).all()
+    assert len(history_keys) == 2


### PR DESCRIPTION
Functional tests current create a keys like 'Key-123456789'. These are never purged though, and in the case of preview stands at over 3000 items.

I explicitly don't just delete all API keys for the service, as functional tests also have a static API key (of a potentially unknown name) which is used to test the external broadcast API.