### PR TITLE
EAS-2957: Update remove_yesterdays_planned_tests_on_govuk_alerts scheduled task.

### DIFF
--- a/app/tasks/scheduled_tasks.py
+++ b/app/tasks/scheduled_tasks.py
@@ -34,7 +34,7 @@ from app.tasks.broadcast_message_tasks import (
     trigger_link_test_secondary_to_A,
     trigger_link_test_secondary_to_B,
 )
-from app.tasks.stub_tasks import publish_govuk_alerts
+from app.tasks.stub_tasks import publish_govuk_alerts, publish_govuk_alerts_full
 
 
 @dramatiq.actor(actor_name=TaskNames.RUN_HEALTH_CHECK, queue_name=QueueNames.PERIODIC, periodic=cron("*/1 * * * *"))
@@ -118,7 +118,7 @@ def remove_yesterdays_planned_tests_on_govuk_alerts():
     # purged from the `publish_task_progress` table
     purge_publish_tasks(days_older_than=1)
 
-    publish_task = publish_govuk_alerts.send()
+    publish_task = publish_govuk_alerts_full.send()
     current_app.logger.info("Enqueued publish GOV UK Alerts for nightly rebuild: %s", publish_task.asdict())
 
 

--- a/app/tasks/stub_tasks.py
+++ b/app/tasks/stub_tasks.py
@@ -7,6 +7,14 @@ from app import dramatiq
 # dramatiq can bind an actor name and queue name in this repo.
 
 
+@dramatiq.actor(actor_name=TaskNames.PUBLISH_GOVUK_ALERTS_FULL, queue_name=QueueNames.GOVUK_ALERTS)
+def publish_govuk_alerts_full(*args, **kwargs):
+    raise NotImplementedError(
+        f"Attempted to run {TaskNames.PUBLISH_GOVUK_ALERTS_FULL} but this is the "
+        "API worker - not govuk. Either this task was sent on the wrong queue or we're consuming the wrong queue."
+    )
+
+
 @dramatiq.actor(actor_name=TaskNames.PUBLISH_GOVUK_ALERTS, queue_name=QueueNames.GOVUK_ALERTS)
 def publish_govuk_alerts(*args, **kwargs):
     raise NotImplementedError(


### PR DESCRIPTION
Now calls a full site publish instead of a dynamic one.
Full site publish completely clears the destination blue/green bucket and copies/re-renders all content, instead of restoring from the previous successful govuk archive.

utils:EAS-2957-blue-green-web-deployments