### PR TITLE
EAS-3027: Adds migration version adding area data tables & scripts to populate table

### DIFF
--- a/migrations/versions/0428_add_area_tables.py
+++ b/migrations/versions/0428_add_area_tables.py
@@ -67,7 +67,7 @@ def upgrade():
         "geography_polygons",
         sa.Column("id", sa.String(), nullable=False),
         sa.Column("name", sa.String(), nullable=True),
-        sa.Column("polygon_data", Geometry("GEOMETRY", srid=4326), nullable=True),
+        sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=True),
         sa.Column("parent_geography_id", sa.String(), nullable=False),
         sa.Column("geography_version_id", sa.String(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
@@ -93,9 +93,9 @@ def upgrade():
         ["geography_version_id"],
     )
     op.create_index(
-        "ix_geography_polygons_polygon_data",
+        "ix_geography_polygons_geometry",
         "geography_polygons",
-        ["polygon_data"],
+        ["geometry"],
         postgresql_using="gist",
     )
 
@@ -113,7 +113,7 @@ def downgrade():
     op.drop_index("ix_geography_polygons_name", table_name="geography_polygons")
     op.drop_index("ix_geography_polygons_parent_geography_id", table_name="geography_polygons")
     op.drop_index("ix_geography_polygons_geography_version_id", table_name="geography_polygons")
-    op.drop_index("ix_geography_polygons_polygon_data", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_geometry", table_name="geography_polygons")
 
     op.drop_table("geography_type")
     op.drop_table("geography_version")

--- a/migrations/versions/0428_add_area_tables.py
+++ b/migrations/versions/0428_add_area_tables.py
@@ -15,6 +15,8 @@ down_revision = "0427_add_area_population_table"
 
 
 def upgrade():
+    # Stores the different geography types, i.e. country, county and unitary
+    # authority, local authority district etc
     op.create_table(
         "geography_type",
         sa.Column("id", sa.String(), nullable=False, unique=True),
@@ -37,20 +39,23 @@ def upgrade():
         ["route"],
     )
 
+    # Stores the different versions, for each geography type, with the source
+    # URL and state (draft, live, deprecated)
     op.create_table(
         "geography_version",
         sa.Column("id", sa.String(), nullable=False),
-        sa.Column("geographic_type_id", sa.String(), nullable=False),
-        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("geography_type_id", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("version", sa.String(), nullable=False),
         sa.Column("source_url", sa.String(), nullable=False),
         sa.Column("state", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["geography_type_id"], ["geography_type.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
-        "ix_geography_version_geographic_type_id",
+        "ix_geography_version_geography_type_id",
         "geography_version",
-        ["geographic_type_id"],
+        ["geography_type_id"],
     )
     op.create_index(
         "ix_geography_version_version",
@@ -63,13 +68,24 @@ def upgrade():
         ["state"],
     )
 
+    # Stores the WKT area for each geography item, as well as parent geography,
+    # geography version and geography type
     op.create_table(
         "geography_polygons",
         sa.Column("id", sa.String(), nullable=False),
-        sa.Column("name", sa.String(), nullable=True),
-        sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=True),
-        sa.Column("parent_geography_id", sa.String(), nullable=False),
-        sa.Column("geography_version_id", sa.String(), nullable=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),
+        sa.Column("parent_geography_id", sa.String(), nullable=True),
+        sa.Column("geography_version_id", sa.String(), nullable=False),
+        sa.Column("geography_type_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["geography_version_id"],
+            ["geography_version.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["geography_type_id"],
+            ["geography_type.id"],
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
@@ -93,6 +109,11 @@ def upgrade():
         ["geography_version_id"],
     )
     op.create_index(
+        "ix_geography_polygons_geography_type_id",
+        "geography_polygons",
+        ["geography_type_id"],
+    )
+    op.create_index(
         "ix_geography_polygons_geometry",
         "geography_polygons",
         ["geometry"],
@@ -101,20 +122,21 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_index("ix_geography_type_id", table_name="geography_type_id")
-    op.drop_index("ix_geography_type_name", table_name="geography_type_id")
-    op.drop_index("ix_geography_type_route", table_name="geography_type_id")
-
-    op.drop_index("ix_geography_version_geographic_type_id", table_name="geography_version")
-    op.drop_index("ix_geography_version_version", table_name="geography_version")
-    op.drop_index("ix_geography_version_state", table_name="geography_version")
-
-    op.drop_index("ix_geography_polygons_id", table_name="geography_polygons")
-    op.drop_index("ix_geography_polygons_name", table_name="geography_polygons")
-    op.drop_index("ix_geography_polygons_parent_geography_id", table_name="geography_polygons")
-    op.drop_index("ix_geography_polygons_geography_version_id", table_name="geography_polygons")
     op.drop_index("ix_geography_polygons_geometry", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_geography_type_id", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_geography_version_id", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_parent_geography_id", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_name", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_id", table_name="geography_polygons")
 
-    op.drop_table("geography_type")
-    op.drop_table("geography_version")
+    op.drop_index("ix_geography_version_state", table_name="geography_version")
+    op.drop_index("ix_geography_version_version", table_name="geography_version")
+    op.drop_index("ix_geography_version_geography_type_id", table_name="geography_version")
+
+    op.drop_index("ix_geography_type_route", table_name="geography_type")
+    op.drop_index("ix_geography_type_name", table_name="geography_type")
+    op.drop_index("ix_geography_type_id", table_name="geography_type")
+
     op.drop_table("geography_polygons")
+    op.drop_table("geography_version")
+    op.drop_table("geography_type")

--- a/migrations/versions/0428_add_area_tables.py
+++ b/migrations/versions/0428_add_area_tables.py
@@ -1,0 +1,121 @@
+"""
+
+Revision ID: 0428_add_area_tables
+Revises: 0427_add_area_population_table
+Create Date: 2026-06-16 15:28:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from geoalchemy2 import Geometry
+
+
+revision = '0428_add_area_tables'
+down_revision = '0427_add_area_population_table'
+
+
+def upgrade():
+    op.create_table(
+        "geography_type",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("route", sa.String(), nullable=True),
+    )
+    op.create_index(
+        "ix_geography_type_id",
+        "geography_type",
+        ["id"],
+    )
+    op.create_index(
+        "ix_geography_type_name",
+        "geography_type",
+        ["name"],
+    )
+    op.create_index(
+        "ix_geography_type_route",
+        "geography_type",
+        ["route"],
+    )
+
+    op.create_table(
+        "geography_version",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("geographic_type_id", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("version", sa.String(), nullable=False),
+        sa.Column("source_url", sa.String(), nullable=False),
+        sa.Column("state", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(
+        "ix_geography_version_geographic_type_id",
+        "geography_version",
+        ["geographic_type_id"],
+    )
+    op.create_index(
+        "ix_geography_version_version",
+        "geography_version",
+        ["version"],
+    )
+    op.create_index(
+        "ix_geography_version_state",
+        "geography_version",
+        ["state"],
+    )
+
+    op.create_table(
+        "geography_polygons",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("polygon_data", Geometry("GEOMETRY", srid=4326), nullable=True),
+        sa.Column("parent_geography_id", sa.String(), nullable=False),
+        sa.Column("geography_version_id", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(
+        "ix_geography_polygons_id",
+        "geography_polygons",
+        ["id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_name",
+        "geography_polygons",
+        ["name"],
+    )
+    op.create_index(
+        "ix_geography_polygons_parent_geography_id",
+        "geography_polygons",
+        ["parent_geography_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_version_id",
+        "geography_polygons",
+        ["geography_version_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_polygon_data",
+        "geography_polygons",
+        ["polygon_data"],
+        postgresql_using="gist",
+    )
+
+
+def downgrade():
+    op.drop_index("ix_geography_type_id", table_name="geography_type_id")
+    op.drop_index("ix_geography_type_name", table_name="geography_type_id")
+    op.drop_index("ix_geography_type_route", table_name="geography_type_id")
+
+    op.drop_index("ix_geography_version_geographic_type_id", table_name="geography_version")
+    op.drop_index("ix_geography_version_version", table_name="geography_version")
+    op.drop_index("ix_geography_version_state", table_name="geography_version")
+
+    op.drop_index("ix_geography_polygons_id", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_name", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_parent_geography_id", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_geography_version_id", table_name="geography_polygons")
+    op.drop_index("ix_geography_polygons_polygon_data", table_name="geography_polygons")
+
+    op.drop_table("geography_type")
+    op.drop_table("geography_version")
+    op.drop_table("geography_polygons")

--- a/migrations/versions/0428_add_area_tables.py
+++ b/migrations/versions/0428_add_area_tables.py
@@ -10,9 +10,8 @@ import sqlalchemy as sa
 from alembic import op
 from geoalchemy2 import Geometry
 
-
-revision = '0428_add_area_tables'
-down_revision = '0427_add_area_population_table'
+revision = "0428_add_area_tables"
+down_revision = "0427_add_area_population_table"
 
 
 def upgrade():
@@ -46,7 +45,7 @@ def upgrade():
         sa.Column("version", sa.String(), nullable=False),
         sa.Column("source_url", sa.String(), nullable=False),
         sa.Column("state", sa.String(), nullable=False),
-        sa.PrimaryKeyConstraint('id')
+        sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
         "ix_geography_version_geographic_type_id",
@@ -71,7 +70,7 @@ def upgrade():
         sa.Column("polygon_data", Geometry("GEOMETRY", srid=4326), nullable=True),
         sa.Column("parent_geography_id", sa.String(), nullable=False),
         sa.Column("geography_version_id", sa.String(), nullable=True),
-        sa.PrimaryKeyConstraint('id')
+        sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(
         "ix_geography_polygons_id",

--- a/migrations/versions/0428_add_area_tables.py
+++ b/migrations/versions/0428_add_area_tables.py
@@ -17,9 +17,9 @@ down_revision = "0427_add_area_population_table"
 def upgrade():
     op.create_table(
         "geography_type",
-        sa.Column("id", sa.String(), nullable=False),
-        sa.Column("name", sa.String(), nullable=False),
-        sa.Column("route", sa.String(), nullable=True),
+        sa.Column("id", sa.String(), nullable=False, unique=True),
+        sa.Column("name", sa.String(), nullable=False, unique=True),
+        sa.Column("route", sa.String(), nullable=True, unique=True),
     )
     op.create_index(
         "ix_geography_type_id",

--- a/migrations/versions/0428_add_area_tables.py
+++ b/migrations/versions/0428_add_area_tables.py
@@ -58,11 +58,6 @@ def upgrade():
         ["geography_type_id"],
     )
     op.create_index(
-        "ix_geography_version_version",
-        "geography_version",
-        ["version"],
-    )
-    op.create_index(
         "ix_geography_version_state",
         "geography_version",
         ["state"],
@@ -130,7 +125,6 @@ def downgrade():
     op.drop_index("ix_geography_polygons_id", table_name="geography_polygons")
 
     op.drop_index("ix_geography_version_state", table_name="geography_version")
-    op.drop_index("ix_geography_version_version", table_name="geography_version")
     op.drop_index("ix_geography_version_geography_type_id", table_name="geography_version")
 
     op.drop_index("ix_geography_type_route", table_name="geography_type")

--- a/migrations/versions/0428_add_area_tables.py
+++ b/migrations/versions/0428_add_area_tables.py
@@ -72,6 +72,8 @@ def upgrade():
         sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),
         sa.Column("parent_geography_id", sa.String(), nullable=True),
         sa.Column("geography_version_id", sa.String(), nullable=False),
+        # Stored for optimisation purposes - not strictly necessary as we can retrieve
+        # geography_type_id from geography_version relation in first instance
         sa.Column("geography_type_id", sa.String(), nullable=False),
         sa.ForeignKeyConstraint(
             ["geography_version_id"],

--- a/requirements.in
+++ b/requirements.in
@@ -30,6 +30,7 @@ SQLAlchemy==1.4.54
 GeoAlchemy2==0.20.0
 urllib3==2.7.0
 Werkzeug==3.1.8
+pandas==3.0.4
 
 # Package for testing
 black==26.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -113,8 +113,6 @@ googleapis-common-protos==1.72.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.5.0
-    # via sqlalchemy
 grpcio==1.76.0
     # via opentelemetry-exporter-otlp-proto-grpc
 idna==3.18
@@ -174,6 +172,8 @@ mypy-extensions==1.1.0
     # via black
 notifications-python-client==10.0.1
     # via -r requirements.in
+numpy==2.5.0
+    # via pandas
 opentelemetry-api==1.33.1
     # via
     #   aws-opentelemetry-distro
@@ -484,6 +484,8 @@ packaging==25.0
     #   opentelemetry-instrumentation-pika
     #   opentelemetry-instrumentation-sqlalchemy
     #   pytest
+pandas==3.0.4
+    # via -r requirements.in
 pathspec==1.0.4
     # via black
 pendulum==3.2.0
@@ -541,6 +543,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   freezegun
     #   moto
+    #   pandas
     #   pendulum
 python-dotenv==1.2.2
     # via pytest-env

--- a/scripts/adding_area_data/add_areas_data.py
+++ b/scripts/adding_area_data/add_areas_data.py
@@ -1,0 +1,102 @@
+import os
+import uuid
+from datetime import datetime, timezone
+import pandas as pd
+
+from utils import (
+    copy_dataframe_to_table,
+    create_db_connection,
+    get_source_data,
+    insert_data_into_table,
+)
+
+VERSION = "1.0.0"
+AREAS_SOURCE_BUCKET = os.environ.get("AREAS_SOURCE_BUCKET_NAME")
+
+AREAS = [
+    "postcodes",
+    "countries",
+    "counties_and_unitary_authorities",
+    "reppir_sites",
+    "test",
+    "local_authority_districts",
+    "flood_warning_areas",
+    "wards",
+]
+
+GEOGRAPHY_POLYGON_COLUMNS = [
+    "id",
+    "name",
+    "geometry",
+    "parent_geography_id",
+    "geography_version_id",
+    "geography_type_id",
+]
+
+
+def insert_geography_version(conn, area, geography_type_id):
+    # Inserts geography_version row for a given area
+    geography_version_id = str(uuid.uuid4())
+    insert_data_into_table(
+        conn,
+        "geography_version",
+        ["id", "geography_type_id", "created_at", "version", "source_url", "state"],
+        [
+            (
+                geography_version_id,
+                geography_type_id,
+                datetime.now(timezone.utc),
+                VERSION,
+                f"s3://{AREAS_SOURCE_BUCKET}/{VERSION}/{area}.csv",
+                "active",
+            )
+        ],
+    )
+    return geography_version_id
+
+
+def insert_geography_type(conn, area):
+    # Inserts geography_type row for a given area
+    geography_type_id = str(uuid.uuid4())
+    insert_data_into_table(
+        conn,
+        "geography_type",
+        ("id", "name", "route"),
+        [(geography_type_id, area, area)],
+    )
+    return geography_type_id
+
+
+def insert_geography_polygons(conn, area, geography_version_id, geography_type_id):
+    # Insert geography_polygons rows for a given area
+    data = get_source_data(f"{VERSION}/{area}.csv")
+    csv_data = pd.read_csv(data, index_col=False)
+
+    # Adds columns for geography_version_id & geography_type_id, values are generated within this script
+    csv_data["geography_version_id"] = geography_version_id
+    csv_data["geography_type_id"] = geography_type_id
+
+    try:
+        copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, csv_data)
+        print(f"{area} geography_polygons data has been added to the table")
+    except Exception as exc:
+        print(f"Could not add {area} data to geography_polygons table: {exc}")
+
+
+def main():
+    # Uses psycopg2 connection to create cursor for database connection
+    conn = create_db_connection()
+
+    try:
+        for area in AREAS:
+            # We have 3 tables; geography_type, geography_version, geography_polygons
+            # For each area we populate them with relevant data
+            geography_type_id = insert_geography_type(conn, area)
+            geography_version_id = insert_geography_version(conn, area, geography_type_id)
+            insert_geography_polygons(conn, area, geography_version_id, geography_type_id)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/adding_area_data/add_areas_data.py
+++ b/scripts/adding_area_data/add_areas_data.py
@@ -70,17 +70,19 @@ def insert_geography_type(conn, area):
 def insert_geography_polygons(conn, area, geography_version_id, geography_type_id):
     # Insert geography_polygons rows for a given area
     data = get_source_data(f"{VERSION}/{area}.csv")
-    csv_data = pd.read_csv(data, index_col=False)
+    # Splits CSV into chunks for processing
+    csv_data_chunks = pd.read_csv(data, index_col=False, chunksize=100000)
 
-    # Adds columns for geography_version_id & geography_type_id, values are generated within this script
-    csv_data["geography_version_id"] = geography_version_id
-    csv_data["geography_type_id"] = geography_type_id
+    for chunk in csv_data_chunks:
+        # Adds columns for geography_version_id & geography_type_id, values are generated within this script
+        chunk["geography_version_id"] = geography_version_id
+        chunk["geography_type_id"] = geography_type_id
 
-    try:
-        copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, csv_data)
-        print(f"{area} geography_polygons data has been added to the table")
-    except Exception as exc:
-        print(f"Could not add {area} data to geography_polygons table: {exc}")
+        try:
+            copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, chunk, with_header=False)
+            print(f"{area} geography_polygons data has been added to the table")
+        except Exception as exc:
+            print(f"Could not add {area} data to geography_polygons table: {exc}")
 
 
 def main():

--- a/scripts/adding_area_data/add_areas_data.py
+++ b/scripts/adding_area_data/add_areas_data.py
@@ -72,14 +72,13 @@ def insert_geography_polygons(conn, area, geography_version_id, geography_type_i
     data = get_source_data(f"{VERSION}/{area}.csv")
     # Splits CSV into chunks for processing
     csv_data_chunks = pd.read_csv(data, index_col=False, chunksize=100000)
-
     for chunk in csv_data_chunks:
         # Adds columns for geography_version_id & geography_type_id, values are generated within this script
         chunk["geography_version_id"] = geography_version_id
         chunk["geography_type_id"] = geography_type_id
 
         try:
-            copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, chunk, with_header=False)
+            copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, chunk)
             print(f"{area} geography_polygons data has been added to the table")
         except Exception as exc:
             print(f"Could not add {area} data to geography_polygons table: {exc}")
@@ -91,6 +90,7 @@ def main():
 
     try:
         for area in AREAS:
+            print(f'Processing {area} data')
             # We have 3 tables; geography_type, geography_version, geography_polygons
             # For each area we populate them with relevant data
             geography_type_id = insert_geography_type(conn, area)

--- a/scripts/adding_area_data/add_areas_data.py
+++ b/scripts/adding_area_data/add_areas_data.py
@@ -92,7 +92,7 @@ def main():
 
     try:
         for area in AREAS:
-            print(f'Processing {area} data')
+            print(f"Processing {area} data")
             # We have 3 tables; geography_type, geography_version, geography_polygons
             # For each area we populate them with relevant data
             geography_type_id = insert_geography_type(conn, area)

--- a/scripts/adding_area_data/add_areas_data.py
+++ b/scripts/adding_area_data/add_areas_data.py
@@ -70,8 +70,9 @@ def insert_geography_type(conn, area):
 def insert_geography_polygons(conn, area, geography_version_id, geography_type_id):
     # Insert geography_polygons rows for a given area
     data = get_source_data(f"{VERSION}/{area}.csv")
-    # Splits CSV into chunks for processing
+    # Splits CSV into chunks for chunk/batch processing
     csv_data_chunks = pd.read_csv(data, index_col=False, chunksize=100000)
+    current_chunk = 1
     for chunk in csv_data_chunks:
         # Adds columns for geography_version_id & geography_type_id, values are generated within this script
         chunk["geography_version_id"] = geography_version_id
@@ -79,7 +80,8 @@ def insert_geography_polygons(conn, area, geography_version_id, geography_type_i
 
         try:
             copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, chunk)
-            print(f"{area} geography_polygons data has been added to the table")
+            print(f"{area} geography_polygons data has been added to the table - chunk #{current_chunk}")
+            current_chunk += 1
         except Exception as exc:
             print(f"Could not add {area} data to geography_polygons table: {exc}")
 

--- a/scripts/adding_area_data/add_population_data.py
+++ b/scripts/adding_area_data/add_population_data.py
@@ -1,22 +1,20 @@
-import psycopg2
 import boto3
 
-from utils import copy_data_to_table, get_environment_variables, get_source_data
+from utils import copy_data_to_table, create_db_connection, get_environment_variables, get_source_data
 
 s3 = boto3.client("s3")
 
 
 def main():
-    # Source variables necessary for DB connection
-    user, password, host, database = get_environment_variables()
-
     # Sources population data to be copied
     population_data = get_source_data("population_data.csv")
 
     # Uses psycopg2 connection to create cursor for database connection
-    conn = psycopg2.connect(host=host, database=database, user=user, password=password)
-
-    copy_data_to_table(data=population_data, conn=conn, table_name="populations", columns=["id", "geometry", "density"])
+    conn = create_db_connection()
+    try:
+        copy_data_to_table(data=population_data, conn=conn, table_name="populations", columns=["id", "geometry", "density"])
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/scripts/adding_area_data/add_population_data.py
+++ b/scripts/adding_area_data/add_population_data.py
@@ -1,6 +1,6 @@
 import boto3
 
-from utils import copy_data_to_table, create_db_connection, get_environment_variables, get_source_data
+from utils import copy_data_to_table, create_db_connection, get_source_data
 
 s3 = boto3.client("s3")
 

--- a/scripts/adding_area_data/add_population_data.py
+++ b/scripts/adding_area_data/add_population_data.py
@@ -12,7 +12,9 @@ def main():
     # Uses psycopg2 connection to create cursor for database connection
     conn = create_db_connection()
     try:
-        copy_data_to_table(data=population_data, conn=conn, table_name="populations", columns=["id", "geometry", "density"])
+        copy_data_to_table(
+            data=population_data, conn=conn, table_name="populations", columns=["id", "geometry", "density"]
+        )
     finally:
         conn.close()
 

--- a/scripts/adding_area_data/utils.py
+++ b/scripts/adding_area_data/utils.py
@@ -1,5 +1,6 @@
 import os
 import boto3
+import psycopg2
 
 s3 = boto3.client("s3")
 
@@ -18,6 +19,12 @@ def get_environment_variables():
     return user, password, host, database
 
 
+def create_db_connection():
+    # Create and return a psycopg2 connection, created using environment variables
+    user, password, host, database = get_environment_variables()
+    return psycopg2.connect(host=host, database=database, user=user, password=password)
+
+
 def copy_data_to_table(data, conn, table_name, columns):
     try:
         with conn, conn.cursor() as curr:
@@ -30,5 +37,15 @@ def copy_data_to_table(data, conn, table_name, columns):
         print(f"{table_name} data has been added to the table")
     except Exception as e:
         print(f"Could not add data to {table_name} table as {e}")
-    finally:
-        conn.close()
+
+
+def insert_data_into_table(conn, table_name, columns, values):
+    query = f"""
+        INSERT INTO {table_name} ({', '.join(columns)}) VALUES ({', '.join(['%s']*len(columns))})
+    """
+    try:
+        with conn, conn.cursor() as curr:
+            curr.executemany(query, values)
+        print(f"{table_name} data has been added to the table")
+    except Exception as e:
+        print(f"Could not add data to {table_name} table as {e}")

--- a/scripts/adding_area_data/utils.py
+++ b/scripts/adding_area_data/utils.py
@@ -26,13 +26,14 @@ def create_db_connection():
     return psycopg2.connect(host=host, database=database, user=user, password=password)
 
 
-def copy_from_stdin(conn, table_name, columns, data):
-    # Runs COPY ... FROM STDIN WITH CSV HEADER
+def copy_from_stdin(conn, table_name, columns, data, with_header=True):
+    # Runs COPY ... FROM STDIN
+    header_clause = "WITH CSV HEADER" if with_header else "WITH CSV"
     with conn, conn.cursor() as curr:
         curr.copy_expert(
             f"""
             COPY {table_name} ({",".join(columns)})
-            FROM STDIN WITH CSV HEADER
+            FROM STDIN {header_clause}
             """,
             data,
         )
@@ -46,12 +47,12 @@ def copy_data_to_table(data, conn, table_name, columns):
         print(f"Could not add data to {table_name} table: {exc}")
 
 
-def copy_dataframe_to_table(conn, table_name, columns, df):
+def copy_dataframe_to_table(conn, table_name, columns, df, with_header=True):
     # Copy a DataFrame into a table
     sio = StringIO()
     df.to_csv(sio, index=False, columns=columns)
     sio.seek(0)
-    copy_from_stdin(conn, table_name, columns, sio)
+    copy_from_stdin(conn, table_name, columns, sio, with_header=with_header)
 
 
 def insert_data_into_table(conn, table_name, columns, values):

--- a/scripts/adding_area_data/utils.py
+++ b/scripts/adding_area_data/utils.py
@@ -1,13 +1,14 @@
+from io import StringIO
 import os
 import boto3
 import psycopg2
 
 s3 = boto3.client("s3")
+AREAS_SOURCE_BUCKET = os.environ.get("AREAS_SOURCE_BUCKET_NAME")
 
 
 def get_source_data(filename):
-    areas_source_bucket = os.environ.get("AREAS_SOURCE_BUCKET_NAME")
-    file = s3.get_object(Bucket=areas_source_bucket, Key=filename)
+    file = s3.get_object(Bucket=AREAS_SOURCE_BUCKET, Key=filename)
     return file["Body"]
 
 
@@ -25,18 +26,32 @@ def create_db_connection():
     return psycopg2.connect(host=host, database=database, user=user, password=password)
 
 
+def copy_from_stdin(conn, table_name, columns, data):
+    # Runs COPY ... FROM STDIN WITH CSV HEADER
+    with conn, conn.cursor() as curr:
+        curr.copy_expert(
+            f"""
+            COPY {table_name} ({",".join(columns)})
+            FROM STDIN WITH CSV HEADER
+            """,
+            data,
+        )
+
+
 def copy_data_to_table(data, conn, table_name, columns):
     try:
-        with conn, conn.cursor() as curr:
-            curr.copy_expert(
-                f"""
-                COPY {table_name} ({",".join(columns)}) FROM STDIN WITH CSV HEADER
-                """,
-                data,
-            )
+        copy_from_stdin(conn, table_name, columns, data)
         print(f"{table_name} data has been added to the table")
-    except Exception as e:
-        print(f"Could not add data to {table_name} table as {e}")
+    except Exception as exc:
+        print(f"Could not add data to {table_name} table: {exc}")
+
+
+def copy_dataframe_to_table(conn, table_name, columns, df):
+    # Copy a DataFrame into a table
+    sio = StringIO()
+    df.to_csv(sio, index=False, columns=columns)
+    sio.seek(0)
+    copy_from_stdin(conn, table_name, columns, sio)
 
 
 def insert_data_into_table(conn, table_name, columns, values):

--- a/scripts/adding_area_data/utils.py
+++ b/scripts/adding_area_data/utils.py
@@ -26,14 +26,13 @@ def create_db_connection():
     return psycopg2.connect(host=host, database=database, user=user, password=password)
 
 
-def copy_from_stdin(conn, table_name, columns, data, with_header=True):
-    # Runs COPY ... FROM STDIN
-    header_clause = "WITH CSV HEADER" if with_header else "WITH CSV"
+def copy_from_stdin(conn, table_name, columns, data):
+    # Runs COPY ... FROM STDIN WITH CSV HEADER
     with conn, conn.cursor() as curr:
         curr.copy_expert(
             f"""
             COPY {table_name} ({",".join(columns)})
-            FROM STDIN {header_clause}
+            FROM STDIN WITH CSV HEADER
             """,
             data,
         )
@@ -47,12 +46,12 @@ def copy_data_to_table(data, conn, table_name, columns):
         print(f"Could not add data to {table_name} table: {exc}")
 
 
-def copy_dataframe_to_table(conn, table_name, columns, df, with_header=True):
+def copy_dataframe_to_table(conn, table_name, columns, df):
     # Copy a DataFrame into a table
     sio = StringIO()
     df.to_csv(sio, index=False, columns=columns)
     sio.seek(0)
-    copy_from_stdin(conn, table_name, columns, sio, with_header=with_header)
+    copy_from_stdin(conn, table_name, columns, sio)
 
 
 def insert_data_into_table(conn, table_name, columns, values):


### PR DESCRIPTION
This PR includes the addition of a migration version, to add the relevant `geography-` tables, as well as a script to copy the area data over from CSV to the database.