### PR TITLE
EAS-3121 Enforce API Key Scope

### DIFF
--- a/app/broadcast_message/translators.py
+++ b/app/broadcast_message/translators.py
@@ -6,28 +6,43 @@ def cap_xml_to_dict(cap_xml):
     # We explicitly tell BS4 that we're expecting utf-8 here, otherwise it uses encoding detection heuristics that
     # can sometimes make the wrong call.
     cap = BeautifulSoup(cap_xml, "xml", from_encoding="utf-8")
+    alert = cap.alert
+    # <info> is optional in the CAP 1.2 schema (minOccurs=0). A Cancel only needs
+    # <references>, so we guard every <info> access here rather than dereferencing
+    # blindly — missing fields then surface as schema validation errors (400) rather
+    # than an AttributeError (500).
+    info = alert.info
 
-    return {
-        "msgType": cap.alert.msgType.text,
-        "reference": cap.alert.identifier.text,
+    broadcast = {
+        "msgType": alert.msgType.text,
+        "reference": alert.identifier.text,
         "references": (
             # references to previous events belonging to the same alert
-            cap.alert.references.text
-            if cap.alert.references
+            alert.references.text
+            if alert.references
             else None
         ),
-        "cap_event": cap.alert.info.event.text,
-        "category": cap.alert.info.category.text,
-        "expires": cap.alert.info.expires.text,
-        "content": cap.alert.info.description.text,
-        "areas": [
+        "cap_event": None,
+        "category": None,
+        "expires": None,
+        "content": None,
+        "areas": [],
+    }
+
+    if info is not None:
+        broadcast["cap_event"] = info.event.text if info.event else None
+        broadcast["category"] = info.category.text if info.category else None
+        broadcast["expires"] = info.expires.text if info.expires else None
+        broadcast["content"] = info.description.text if info.description else None
+        broadcast["areas"] = [
             {
                 "name": area.areaDesc.text,
                 "polygons": [cap_xml_polygon_to_list(polygon.text) for polygon in area.find_all("polygon")],
             }
-            for area in cap.alert.info.find_all("area")
-        ],
-    }
+            for area in info.find_all("area")
+        ]
+
+    return broadcast
 
 
 def cap_xml_polygon_to_list(polygon_string):

--- a/app/v2/broadcast/broadcast_schemas.py
+++ b/app/v2/broadcast/broadcast_schemas.py
@@ -119,3 +119,29 @@ post_broadcast_schema = {
         },
     },
 }
+
+# A Cancel only acts on <references> (to look up the alert being cancelled), so it
+# doesn't need the cap_event / category / content / areas that an Alert requires.
+# The route still emits a friendlier error than jsonschema for a missing
+# <references>, so we accept null here and let the handler raise that.
+cancel_broadcast_schema = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "required": [
+        "msgType",
+    ],
+    "properties": {
+        "msgType": {
+            "type": "string",
+            "enum": [
+                "Cancel",
+            ],
+        },
+        "references": {
+            "type": [
+                "string",
+                "null",
+            ],
+        },
+    },
+}

--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -19,7 +19,10 @@ from app.dao.dao_utils import dao_save_object
 from app.models import BROADCAST_TYPE, BroadcastMessage, BroadcastStatusType
 from app.schema_validation import validate
 from app.v2.broadcast import v2_broadcast_blueprint
-from app.v2.broadcast.broadcast_schemas import post_broadcast_schema
+from app.v2.broadcast.broadcast_schemas import (
+    cancel_broadcast_schema,
+    post_broadcast_schema,
+)
 from app.v2.errors import BadRequestError, ValidationError
 from app.xml_schemas import validate_xml
 
@@ -51,9 +54,11 @@ def create_broadcast():
         )
 
     broadcast_json = cap_xml_to_dict(cap_xml)
-    validate(broadcast_json, post_broadcast_schema)
 
     if broadcast_json["msgType"] == "Cancel":
+        # A Cancel only needs <references>; it doesn't carry the alert content an
+        # Alert does, so validate against the slimmer schema and skip the Alert path.
+        validate(broadcast_json, cancel_broadcast_schema)
         if broadcast_json["references"] is None:
             raise BadRequestError(
                 message="Unable to cancel broadcast. Cap_xml is missing field: <references>",
@@ -66,6 +71,7 @@ def create_broadcast():
         return jsonify(broadcast_message.serialize()), 201
 
     else:
+        validate(broadcast_json, post_broadcast_schema)
         _validate_template(broadcast_json)
 
         polygons = Polygons(

--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -1,5 +1,6 @@
 from itertools import chain
 
+from emergency_alerts_utils.api_key import KEY_TYPE_TEAM, KEY_TYPE_TEST
 from emergency_alerts_utils.polygons import Polygons
 from emergency_alerts_utils.template import BroadcastMessageTemplate
 from flask import current_app, jsonify, make_response, request
@@ -8,6 +9,7 @@ from shapely.validation import explain_validity
 from sqlalchemy.orm.exc import MultipleResultsFound
 
 from app import api_user, authenticated_service
+from app.authentication.auth import AuthError
 from app.broadcast_message import utils as broadcast_utils
 from app.broadcast_message.translators import cap_xml_to_dict
 from app.dao.broadcast_message_dao import (
@@ -29,6 +31,7 @@ def create_broadcast():
         BROADCAST_TYPE,
         authenticated_service.permissions,
     )
+    _check_key_type_allowed(api_user.key_type)
 
     if request.content_type != "application/cap+xml":
         raise BadRequestError(
@@ -100,7 +103,7 @@ def create_broadcast():
             },
             status=BroadcastStatusType.PENDING_APPROVAL,
             created_by_api_key_id=api_user.id,
-            stubbed=authenticated_service.restricted,
+            stubbed=authenticated_service.restricted or api_user.key_type == KEY_TYPE_TEST,
             # The client may pass in broadcast_json['expires'] but it’s
             # simpler for now to ignore it and have the rules around expiry
             # for broadcasts created with the API match those created from
@@ -140,6 +143,9 @@ def _cancel_or_reject_broadcast(references_to_original_broadcast, service_id):
             status_code=400,
         )
 
+    if api_user.key_type == KEY_TYPE_TEST and not broadcast_message.stubbed:
+        raise AuthError("Cannot cancel a live broadcast with a test API key", 403)
+
     if broadcast_message.status == BroadcastStatusType.PENDING_APPROVAL:
         new_status = BroadcastStatusType.REJECTED
     else:
@@ -162,6 +168,14 @@ def _validate_template(broadcast_json):
 def _check_service_has_permission(type, permissions):
     if type not in permissions:
         raise BadRequestError(message="Service is not allowed to send broadcast messages")
+
+
+def _check_key_type_allowed(key_type):
+    # Team keys are a legacy Notify grouping of 'team & guest list', so they are not
+    # allowed to create, cancel or reject alerts. Test keys are allowed but their
+    # broadcasts are forced to be stubbed (see create_broadcast / _cancel_or_reject_broadcast).
+    if key_type == KEY_TYPE_TEAM:
+        raise AuthError("Cannot send broadcasts with a team API key", 403)
 
 
 def _validate_polygons(polygons):

--- a/docs/broadcast-cap-xml.md
+++ b/docs/broadcast-cap-xml.md
@@ -1,0 +1,100 @@
+# Broadcast CAP XML request format
+
+The public `POST /v2/broadcast` endpoint (see [`app/v2/broadcast/post_broadcast.py`](../app/v2/broadcast/post_broadcast.py))
+accepts a [CAP 1.2](https://docs.oasis-open.org/emergency/cap/v1.2/CAP-v1.2.html) `<alert>`
+document. The request `Content-Type` **must** be `application/cap+xml`; any other content
+type returns `415`.
+
+The payload is validated in three stages, in this order:
+
+1. **CAP 1.2 schema** (`CAP-v1.2.xsd`) — structural validation. CAP defines `<alert>` as an
+   `xs:sequence`, so child elements must appear in the schema-mandated order, not just be
+   present (see [element ordering](#element-ordering) below).
+2. **Translation** — [`cap_xml_to_dict`](../app/broadcast_message/translators.py) extracts the
+   fields we use into a JSON object.
+3. **JSON schema** — [`broadcast_schemas.py`](../app/v2/broadcast/broadcast_schemas.py)
+   validates that object. A different schema applies depending on `<msgType>`.
+
+## Message types
+
+We support two `<msgType>` values: `Alert` (create a new broadcast) and `Cancel`
+(cancel/reject an existing one). `Update`, `Ack`, and `Error` are valid CAP but not
+currently supported.
+
+The required elements differ significantly between the two, because a `Cancel` only needs to
+identify the alert being cancelled — it does not carry any content of its own.
+
+### Alert
+
+A new broadcast must supply the full alert. Required elements:
+
+| Element | Notes |
+| --- | --- |
+| `<identifier>` | Becomes the broadcast `reference`. |
+| `<sender>` | Must match the CAP `sender` pattern. |
+| `<sent>` | `YYYY-MM-DDThh:mm:ss±hh:mm`. |
+| `<status>` | e.g. `Actual`. |
+| `<msgType>` | `Alert`. |
+| `<scope>` | e.g. `Public`. |
+| `<info>` | Required. Must contain the elements below. |
+| `<info><category>` | Must be one of the CAP categories (`Geo`, `Met`, `Safety`, …). |
+| `<info><event>` | Free text; becomes `cap_event`. |
+| `<info><urgency>` / `<severity>` / `<certainty>` | Required by the CAP schema. The values are not used by us, but must be valid CAP enum values. |
+| `<info><description>` | The broadcast content. May be empty, but the element must be present. |
+| `<info><area>` | At least one. Each `<area>` needs an `<areaDesc>` and at least one `<polygon>` of **4 or more** coordinate pairs. |
+
+`<info><expires>` is accepted but ignored — expiry for API-created broadcasts follows the
+same rules as those created in the admin app.
+
+### Cancel
+
+A `Cancel` is matched against existing broadcasts using `<references>`, so that is the only
+content-bearing element it needs. The entire `<info>` block is **optional** and is ignored if
+present.
+
+Required elements:
+
+| Element | Notes |
+| --- | --- |
+| `<identifier>` | Required by the CAP schema. |
+| `<sender>` | Required by the CAP schema. |
+| `<sent>` | Required by the CAP schema. |
+| `<status>` | Required by the CAP schema. |
+| `<msgType>` | `Cancel`. |
+| `<scope>` | Required by the CAP schema. |
+| `<references>` | The alert(s) to cancel, conventionally comma-separated `sender,identifier,sent` triples (the code splits on `,` and matches against stored references). An absent `<references>` element returns `400`; an empty one (`<references></references>`) is treated as a reference that matches nothing and returns `404`. |
+
+If `<references>` matches a broadcast that is still `pending-approval` it is **rejected**;
+otherwise it is **cancelled**. If `<references>` lists more than one distinct broadcast the
+request is rejected with `400` (it must uniquely identify a single alert).
+
+A minimal valid `Cancel`:
+
+```xml
+<alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+    <identifier>5fc99d720abb86020b233422a503af78E</identifier>
+    <sender>www.gov.uk/environment-agency</sender>
+    <sent>2020-02-16T23:02:26-00:00</sent>
+    <status>Actual</status>
+    <msgType>Cancel</msgType>
+    <scope>Public</scope>
+    <references>www.gov.uk/environment-agency,50385fcb0ab7aa447bbd46d848ce8466E,2020-02-16T23:01:13-00:00</references>
+</alert>
+```
+
+A `Cancel` may still include a full `<info>` block (it is simply ignored), so existing
+integrations that send one continue to work unchanged.
+
+## Element ordering
+
+Because `<alert>` is a CAP `xs:sequence`, elements must appear in this order. A common
+mistake is placing `<references>` before `<scope>`, which fails schema validation with
+`Element '…references': This element is not expected.`
+
+```
+identifier → sender → sent → status → msgType
+→ source (optional) → scope → restriction (optional) → addresses (optional)
+→ code (optional) → note (optional) → references (optional) → incidents (optional) → info
+```
+
+So `<references>` must come **after** `<scope>`, not immediately after `<msgType>`.

--- a/docs/writing-public-apis.md
+++ b/docs/writing-public-apis.md
@@ -6,6 +6,8 @@ _Most of the API endpoints in this repo are for internal use. These are all defi
 
 Public APIs are intended for use by services and are all located under `app/v2/` to distinguish them from internal endpoints. Originally we did have a "v1" public API, where we tried to reuse / expose existing internal endpoints. The needs for public APIs are sufficiently different that we decided to separate them out. Any "v1" endpoints that remain are now purely internal and no longer exposed to services.
 
+For the request format of the public broadcast endpoint specifically, see [Broadcast CAP XML request format](broadcast-cap-xml.md).
+
 ## New APIs
 
 Here are some pointers for how we write public API endpoints.

--- a/openapi/emergency-alerts-api-external.yaml
+++ b/openapi/emergency-alerts-api-external.yaml
@@ -106,23 +106,6 @@ paths:
                   msgType: 'Cancel'
                   scope: 'Public'
                   references: 'www.gov.uk/environment-agency,d0cb0757-db2d-4a6e-a477-1cc0aff18519,2024-11-18T15:22:13-01:00'
-                  info:
-                    language: 'en-GB'
-                    category: 'Met'
-                    event: 'Flood Warning 1cc0aff18519'
-                    urgency: 'Immediate'
-                    severity: 'Severe'
-                    certainty: 'Likely'
-                    expires: '2024-11-19T15:22:13-01:00'
-                    senderName: 'Environment Agency'
-                    description: ''
-                    instruction: 'Check the latest information for your area'
-                    area:
-                      areaDesc: 'River Stepping'
-                      polygon: '53.10569,0.24453 53.10593,0.24430 53.10601,0.24375 53.10615,0.24349 53.10629,0.24356 53.10656,0.24336 53.10697,0.24354 53.10684,0.24298 53.10694,0.24264 53.10721,0.24302 53.10752,0.24310 53.10777,0.24308 53.10805,0.24320 53.10803,0.24187 53.10776,0.24085 53.10774,0.24062 53.10702,0.24056 53.10679,0.24088 53.10658,0.24071 53.10651,0.24049 53.10656,0.24022 53.10642,0.24022 53.10632,0.24052 53.10629,0.24082 53.10612,0.24093 53.10583,0.24133 53.10564,0.24178 53.10541,0.24282 53.10569,0.24453'
-                      geocode:
-                        valueName: 'TargetAreaCode'
-                        value: '053FWFSTEEP4'
 
       responses:
         "201":
@@ -191,7 +174,12 @@ components:
           type: string
           description: Required when cancelling an alert - provide extra comma-separated data points, such as \'sender\', \'sent\' timestamp or alert content (\'description\'), to ensure that the alert to be cancelled is uniquely identified (see \'Cancel Alert\' example)
         info:
-          $ref: "#/components/schemas/Info"
+          allOf:
+            - $ref: "#/components/schemas/Info"
+          description: >-
+            Required for Alert messages. Not required for Cancel messages — a
+            Cancel is matched on `references` only, and any `info` block is
+            ignored.
       required:
         - identifier
         - sender
@@ -263,12 +251,15 @@ components:
       properties:
         approved_at:
           type: string
+          nullable: true
         approved_by_id:
           type: string
+          nullable: true
         areas:
           $ref: '#/components/schemas/ResponseAreas'
         cancelled_at:
           type: string
+          nullable: true
         cap_event:
           type: string
         content:
@@ -277,8 +268,10 @@ components:
           type: string
         duration:
           type: string
+          nullable: true
         finishes_at:
           type: string
+          nullable: true
         id:
           type: string
         reference:
@@ -287,10 +280,12 @@ components:
           type: string
         starts_at:
           type: string
+          nullable: true
         status:
           type: string
         updated_at:
           type: string
+          nullable: true
 
     ResponseAreas:
       type: object

--- a/openapi/emergency-alerts-api.yaml
+++ b/openapi/emergency-alerts-api.yaml
@@ -108,23 +108,6 @@ paths:
                   msgType: 'Cancel'
                   scope: 'Public'
                   references: 'www.gov.uk/environment-agency,d0cb0757-db2d-4a6e-a477-1cc0aff18519,2024-11-18T15:22:13-01:00'
-                  info:
-                    language: 'en-GB'
-                    category: 'Met'
-                    event: 'Flood Warning 1cc0aff18519'
-                    urgency: 'Immediate'
-                    severity: 'Severe'
-                    certainty: 'Likely'
-                    expires: '2024-11-19T15:22:13-01:00'
-                    senderName: 'Environment Agency'
-                    description: ''
-                    instruction: 'Check the latest information for your area'
-                    area:
-                      areaDesc: 'River Stepping'
-                      polygon: '53.10569,0.24453 53.10593,0.24430 53.10601,0.24375 53.10615,0.24349 53.10629,0.24356 53.10656,0.24336 53.10697,0.24354 53.10684,0.24298 53.10694,0.24264 53.10721,0.24302 53.10752,0.24310 53.10777,0.24308 53.10805,0.24320 53.10803,0.24187 53.10776,0.24085 53.10774,0.24062 53.10702,0.24056 53.10679,0.24088 53.10658,0.24071 53.10651,0.24049 53.10656,0.24022 53.10642,0.24022 53.10632,0.24052 53.10629,0.24082 53.10612,0.24093 53.10583,0.24133 53.10564,0.24178 53.10541,0.24282 53.10569,0.24453'
-                      geocode:
-                        valueName: 'TargetAreaCode'
-                        value: '053FWFSTEEP4'
 
       responses:
         "201":
@@ -193,7 +176,12 @@ components:
           type: string
           description: Required when cancelling an alert - provide extra comma-separated data points, such as \'sender\', \'sent\' timestamp or alert content (\'description\'), to ensure that the alert to be cancelled is uniquely identified (see \'Cancel Alert\' example)
         info:
-          $ref: "#/components/schemas/Info"
+          allOf:
+            - $ref: "#/components/schemas/Info"
+          description: >-
+            Required for Alert messages. Not required for Cancel messages — a
+            Cancel is matched on `references` only, and any `info` block is
+            ignored.
       required:
         - identifier
         - sender
@@ -265,12 +253,15 @@ components:
       properties:
         approved_at:
           type: string
+          nullable: true
         approved_by_id:
           type: string
+          nullable: true
         areas:
           $ref: '#/components/schemas/ResponseAreas'
         cancelled_at:
           type: string
+          nullable: true
         cap_event:
           type: string
         content:
@@ -279,8 +270,10 @@ components:
           type: string
         duration:
           type: string
+          nullable: true
         finishes_at:
           type: string
+          nullable: true
         id:
           type: string
         reference:
@@ -289,10 +282,12 @@ components:
           type: string
         starts_at:
           type: string
+          nullable: true
         status:
           type: string
         updated_at:
           type: string
+          nullable: true
 
     ResponseAreas:
       type: object

--- a/tests/app/v2/broadcast/sample_cap_xml_documents.py
+++ b/tests/app/v2/broadcast/sample_cap_xml_documents.py
@@ -75,6 +75,20 @@ WAINFLEET_CANCEL_WITH_REFERENCES = WAINFLEET_CANCEL.format(
 WAINFLEET_CANCEL_WITH_MISSING_REFERENCES = WAINFLEET_CANCEL.format("")
 WAINFLEET_CANCEL_WITH_EMPTY_REFERENCES = WAINFLEET_CANCEL.format("<references></references>")
 
+# A Cancel only needs <references>; the <info> block is optional in CAP 1.2 and is
+# ignored on the cancel path, so a minimal Cancel can omit it entirely.
+WAINFLEET_CANCEL_MINIMAL = """
+    <alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+        <identifier>5fc99d720abb86020b233422a503af78E</identifier>
+        <sender>www.gov.uk/environment-agency</sender>
+        <sent>2020-02-16T23:02:26-00:00</sent>
+        <status>Actual</status>
+        <msgType>Cancel</msgType>
+        <scope>Public</scope>
+        <references>www.gov.uk/environment-agency,50385fcb0ab7aa447bbd46d848ce8466E,2020-02-16T23:01:13-00:00</references>
+    </alert>
+"""
+
 WAINFLEET_CANCEL_WITH_WINDMERE_REFERENCES = WAINFLEET_CANCEL.format(
     "<references>"
     # Wainfleet

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -1,6 +1,7 @@
 from unittest.mock import ANY
 
 import pytest
+from emergency_alerts_utils.api_key import KEY_TYPE_TEAM, KEY_TYPE_TEST
 from flask import json
 
 from app.dao.broadcast_message_dao import (
@@ -150,6 +151,114 @@ def test_valid_cancel_broadcast_request_calls_update_broadcast_message_status_an
     )
     assert response_for_cancel.status_code == 201
     mock_update.assert_called_once_with(broadcast_message, expected_status, api_key_id=api_key.id)
+
+
+def test_team_api_key_cannot_create_broadcast_returns_403(client, sample_broadcast_service):
+    auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id, key_type=KEY_TYPE_TEAM)
+
+    response = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET,
+        headers=[("Content-Type", "application/cap+xml"), auth_header],
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["errors"][0]["message"] == "Cannot send broadcasts with a team API key"
+
+
+def test_team_api_key_cannot_cancel_broadcast_returns_403(client, sample_broadcast_service):
+    # Create both keys up front: the api-key collection is cached per service, so a key
+    # created after the first request would not be visible to a later request.
+    live_auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
+    team_auth_header = create_service_authorization_header(
+        service_id=sample_broadcast_service.id, key_type=KEY_TYPE_TEAM
+    )
+
+    # create a real broadcast with a live key
+    response_for_create = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET,
+        headers=[("Content-Type", "application/cap+xml"), live_auth_header],
+    )
+    assert response_for_create.status_code == 201
+
+    response_for_cancel = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET_CANCEL_WITH_REFERENCES,
+        headers=[("Content-Type", "application/cap+xml"), team_auth_header],
+    )
+
+    assert response_for_cancel.status_code == 403
+    assert response_for_cancel.get_json()["errors"][0]["message"] == "Cannot send broadcasts with a team API key"
+
+
+def test_test_api_key_forces_broadcast_to_be_stubbed_on_live_service(client, sample_broadcast_service):
+    # sample_broadcast_service is not restricted (i.e. live), but a test key must still be stubbed
+    assert sample_broadcast_service.restricted is False
+    auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id, key_type=KEY_TYPE_TEST)
+
+    response = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET,
+        headers=[("Content-Type", "application/cap+xml"), auth_header],
+    )
+
+    assert response.status_code == 201
+    response_json = json.loads(response.get_data(as_text=True))
+    broadcast_message = dao_get_broadcast_message_by_id_and_service_id(response_json["id"], sample_broadcast_service.id)
+    assert broadcast_message.stubbed is True
+
+
+def test_test_api_key_cannot_cancel_a_live_broadcast_returns_403(client, sample_broadcast_service):
+    # Create both keys up front: the api-key collection is cached per service, so a key
+    # created after the first request would not be visible to a later request.
+    live_auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
+    test_auth_header = create_service_authorization_header(
+        service_id=sample_broadcast_service.id, key_type=KEY_TYPE_TEST
+    )
+
+    # create a real (non-stubbed) broadcast with a live key
+    response_for_create = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET,
+        headers=[("Content-Type", "application/cap+xml"), live_auth_header],
+    )
+    assert response_for_create.status_code == 201
+
+    response_for_cancel = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET_CANCEL_WITH_REFERENCES,
+        headers=[("Content-Type", "application/cap+xml"), test_auth_header],
+    )
+
+    assert response_for_cancel.status_code == 403
+    assert (
+        response_for_cancel.get_json()["errors"][0]["message"] == "Cannot cancel a live broadcast with a test API key"
+    )
+
+
+def test_test_api_key_can_cancel_its_own_stubbed_broadcast_returns_201(client, sample_broadcast_service, mocker):
+    test_auth_header = create_service_authorization_header(
+        service_id=sample_broadcast_service.id, key_type=KEY_TYPE_TEST
+    )
+
+    # create a stubbed broadcast with the test key
+    response_for_create = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET,
+        headers=[("Content-Type", "application/cap+xml"), test_auth_header],
+    )
+    assert response_for_create.status_code == 201
+
+    mocker.patch("app.v2.broadcast.post_broadcast.broadcast_utils.update_broadcast_message_status")
+
+    response_for_cancel = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET_CANCEL_WITH_REFERENCES,
+        headers=[("Content-Type", "application/cap+xml"), test_auth_header],
+    )
+
+    assert response_for_cancel.status_code == 201
 
 
 @pytest.mark.parametrize(

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -153,6 +153,35 @@ def test_valid_cancel_broadcast_request_calls_update_broadcast_message_status_an
     mock_update.assert_called_once_with(broadcast_message, expected_status, api_key_id=api_key.id)
 
 
+def test_valid_cancel_broadcast_request_without_info_block_returns_201(client, sample_broadcast_service, mocker):
+    api_key = create_api_key(service=sample_broadcast_service)
+    auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
+
+    # create a broadcast
+    response_for_create = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET,
+        headers=[("Content-Type", "application/cap+xml"), auth_header],
+    )
+    assert response_for_create.status_code == 201
+
+    response_json_for_create = json.loads(response_for_create.get_data(as_text=True))
+    broadcast_message = dao_get_broadcast_message_by_id_and_service_id(
+        response_json_for_create["id"], response_json_for_create["service_id"]
+    )
+
+    mock_update = mocker.patch("app.v2.broadcast.post_broadcast.broadcast_utils.update_broadcast_message_status")
+
+    # cancel broadcast with a minimal payload that omits the optional <info> block
+    response_for_cancel = client.post(
+        path="/v2/broadcast",
+        data=sample_cap_xml_documents.WAINFLEET_CANCEL_MINIMAL,
+        headers=[("Content-Type", "application/cap+xml"), auth_header],
+    )
+    assert response_for_cancel.status_code == 201
+    mock_update.assert_called_once_with(broadcast_message, "rejected", api_key_id=api_key.id)
+
+
 def test_team_api_key_cannot_create_broadcast_returns_403(client, sample_broadcast_service):
     auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id, key_type=KEY_TYPE_TEAM)
 


### PR DESCRIPTION
API keys are scoped as follows: Live, Test, Team.
This PR enforces key scoping such that a Test or Team key cannot, for example, cancel a live alert (this restriction was not formerly enforced, as confirmed by manual API testing).
During testing it was also discovered that the Cancel alert payload was being validated against the Broadcast XML schema. A cut-down 'cancel' schema was added to remove unnecessary XML elements.
The payload requirements for broadcast and cancel messages is clarified in extra documentation added in this PR, including the Swagger/OpenApi docs.