### PR TITLE
fix/Increases the default failed publish interval from 10s to 30s

### DIFF
--- a/app/publish_task_progress/rest.py
+++ b/app/publish_task_progress/rest.py
@@ -89,7 +89,7 @@ def parse_task_id(task_id):
     return {"publish_type": publish_type, "publish_origin": publish_origin, "timestamp": timestamp}
 
 
-def has_publish_failed(now, task, failed_publish_interval=10.0):
+def has_publish_failed(now, task, failed_publish_interval=30.0):
     return now - task.last_activity_at.timestamp() > failed_publish_interval
 
 


### PR DESCRIPTION
This PR increases the default value for failed publish interval, from 10s to 30s, to avoid slower processes resulting in failed publish check notifications incorrectly.