### PR TITLE
Uses `GOVUK_PUBLISH_CHECKS_FAILED_INTERVAL` environment variable instead of hardcoded value

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -171,6 +171,11 @@ class Config(object):
     MAX_THROTTLE_PERIOD = 60
 
     GOVUK_ALERTS_S3_BUCKET_NAME = os.getenv("GOVUK_ALERTS_S3_BUCKET_NAME")
+    GOVUK_PUBLISH_CHECKS_FAILED_INTERVAL = (
+        int(os.getenv("GOVUK_PUBLISH_CHECKS_FAILED_INTERVAL"))
+        if os.environ.get("GOVUK_PUBLISH_CHECKS_FAILED_INTERVAL") is not None
+        else 30
+    )
 
     SES_ENDPOINT = os.environ.get("AWS_ENDPOINT_URL_SES", "http://localstack:4566")
     SES_FROM_ADDRESS = "support@localhost"

--- a/app/publish_task_progress/rest.py
+++ b/app/publish_task_progress/rest.py
@@ -1,6 +1,6 @@
 from time import time
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 
 from app.dao.publish_task_progress_dao import (
     dao_create_publish_task,
@@ -89,8 +89,8 @@ def parse_task_id(task_id):
     return {"publish_type": publish_type, "publish_origin": publish_origin, "timestamp": timestamp}
 
 
-def has_publish_failed(now, task, failed_publish_interval=30.0):
-    return now - task.last_activity_at.timestamp() > failed_publish_interval
+def has_publish_failed(now, task):
+    return now - task.last_activity_at.timestamp() > current_app.config.get("GOVUK_PUBLISH_CHECKS_FAILED_INTERVAL")
 
 
 @publish_task_progress_blueprint.route("/purge/<int:days_older_than>", methods=["DELETE"])


### PR DESCRIPTION
This PR adds a variable to config, sourced as an environment variable, for `GOVUK_PUBLISH_CHECKS_FAILED_INTERVAL` and references it within the code where necessary.