### PR TITLE
EAS-3130 Limit cap_xml polygon complexity

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -182,11 +182,6 @@ class Config(object):
     # geometry work runs. The 12-polygon / 250-point thresholds in
     # post_broadcast.py only decide whether to simplify the payload; exceeding
     # these values rejects it with a 400.
-    #
-    # These are safety limits, not functional ones, so they sit well above real
-    # traffic: a whole-UK operator test alert is ~243 polygons / ~8,300 points,
-    # so these leave ~4x / ~6x headroom while still bounding the O(n^2) overlap
-    # check and per-request memory.
     MAX_BROADCAST_POLYGON_COUNT = 1_000
     MAX_BROADCAST_POLYGON_POINT_COUNT = 50_000
 

--- a/app/config.py
+++ b/app/config.py
@@ -174,12 +174,6 @@ class Config(object):
 
     MAX_THROTTLE_PERIOD = 60
 
-    # Cap the size of an incoming request body. A legitimate CAP XML alert is a
-    # few KB; anything approaching this ceiling could be a DoS attack.
-    # Flask rejects the request with 413 before we read or parse the body, so this
-    # is the outermost guard against an oversized payload.
-    MAX_CONTENT_SIZE = 1 * 1024 * 1024  # 1 MB
-
     # Hard ceilings on broadcast geometry, enforced before any Shapely/pyproj
     # geometry work runs. The 12-polygon / 250-point thresholds in
     # post_broadcast.py only decide whether to simplify the payload; exceeding

--- a/app/config.py
+++ b/app/config.py
@@ -176,7 +176,7 @@ class Config(object):
     # few KB; anything approaching this ceiling could be a DoS attack.
     # Flask rejects the request with 413 before we read or parse the body, so this
     # is the outermost guard against an oversized payload.
-    MAX_CONTENT_LENGTH = 1 * 1024 * 1024  # 1 MB
+    MAX_CONTENT_SIZE = 1 * 1024 * 1024  # 1 MB
 
     # Hard ceilings on broadcast geometry, enforced before any Shapely/pyproj
     # geometry work runs. The 12-polygon / 250-point thresholds in

--- a/app/config.py
+++ b/app/config.py
@@ -172,6 +172,24 @@ class Config(object):
 
     MAX_THROTTLE_PERIOD = 60
 
+    # Cap the size of an incoming request body. A legitimate CAP XML alert is a
+    # few KB; anything approaching this ceiling could be a DoS attack.
+    # Flask rejects the request with 413 before we read or parse the body, so this
+    # is the outermost guard against an oversized payload.
+    MAX_CONTENT_LENGTH = 1 * 1024 * 1024  # 1 MB
+
+    # Hard ceilings on broadcast geometry, enforced before any Shapely/pyproj
+    # geometry work runs. The 12-polygon / 250-point thresholds in
+    # post_broadcast.py only decide whether to simplify the payload; exceeding
+    # these values rejects it with a 400.
+    #
+    # These are safety limits, not functional ones, so they sit well above real
+    # traffic: a whole-UK operator test alert is ~243 polygons / ~8,300 points,
+    # so these leave ~4x / ~6x headroom while still bounding the O(n^2) overlap
+    # check and per-request memory.
+    MAX_BROADCAST_POLYGON_COUNT = 1_000
+    MAX_BROADCAST_POLYGON_POINT_COUNT = 50_000
+
     GOVUK_ALERTS_S3_BUCKET_NAME = os.getenv("GOVUK_ALERTS_S3_BUCKET_NAME")
 
     SES_ENDPOINT = os.environ.get("AWS_ENDPOINT_URL_SES", "http://localstack:4566")

--- a/app/v2/broadcast/post_broadcast.py
+++ b/app/v2/broadcast/post_broadcast.py
@@ -1,4 +1,4 @@
-from itertools import chain
+from itertools import chain, combinations
 
 from emergency_alerts_utils.api_key import KEY_TYPE_TEAM, KEY_TYPE_TEST
 from emergency_alerts_utils.polygons import Polygons
@@ -72,6 +72,7 @@ def create_broadcast():
 
     else:
         validate(broadcast_json, post_broadcast_schema)
+        _check_broadcast_complexity(broadcast_json)
         _validate_template(broadcast_json)
 
         polygons = Polygons(
@@ -160,6 +161,37 @@ def _cancel_or_reject_broadcast(references_to_original_broadcast, service_id):
     return broadcast_message
 
 
+def _check_broadcast_complexity(broadcast_json):
+    """
+    Reject excessively large polygons before Shapely/pyproj processing.
+    The 12-polygon / 250-point check in create_broadcast only triggers
+    simplification. Without this check, an authenticated broadcast key
+    could submit thousands of disjoint unmergeable polygons or a single
+    polygon with a huge point count and exhaust API worker CPU/memory.
+    """
+    polygon_count = 0
+    point_count = 0
+    for area in broadcast_json["areas"]:
+        for polygon in area["polygons"]:
+            polygon_count += 1
+            point_count += len(polygon)
+
+    max_polygons = current_app.config["MAX_BROADCAST_POLYGON_COUNT"]
+    max_points = current_app.config["MAX_BROADCAST_POLYGON_POINT_COUNT"]
+
+    if polygon_count > max_polygons:
+        raise BadRequestError(
+            message=f"Too many polygons ({polygon_count}); the maximum is {max_polygons}",
+            status_code=400,
+        )
+
+    if point_count > max_points:
+        raise BadRequestError(
+            message=f"Too many coordinates ({point_count}); the maximum is {max_points}",
+            status_code=400,
+        )
+
+
 def _validate_template(broadcast_json):
     template = BroadcastMessageTemplate.from_content(broadcast_json["content"])
 
@@ -186,19 +218,23 @@ def _check_key_type_allowed(key_type):
 
 def _validate_polygons(polygons):
     try:
-        for polygon1 in polygons:
-            for polygon2 in polygons:
-                p1 = ShapelyPolygon(polygon1) if not isinstance(polygon1, ShapelyPolygon) else polygon1
-                p2 = ShapelyPolygon(polygon2) if not isinstance(polygon2, ShapelyPolygon) else polygon2
-                # Check for overlapping polygons, including partial
-                # intersections and enclosed polygons (holes)
-                if p1 != p2 and p1.intersects(p2):
-                    raise ValidationError(
-                        message="Overlapping areas are not supported.",
-                        status_code=400,
-                    )
-        for polygon in polygons:
-            p = ShapelyPolygon(polygon) if not isinstance(polygon, ShapelyPolygon) else polygon
+        # Build each Shapely polygon exactly once rather than reconstructing both
+        # operands on every pass of the nested loop below. The polygon count is
+        # bounded up front by _check_broadcast_complexity.
+        shapely_polygons = [
+            polygon if isinstance(polygon, ShapelyPolygon) else ShapelyPolygon(polygon) for polygon in polygons
+        ]
+
+        # Check for overlapping polygons, including partial intersections and
+        # enclosed polygons (holes). intersects() is symmetric, so only compare
+        # each unordered pair once.
+        for p1, p2 in combinations(shapely_polygons, 2):
+            if p1.intersects(p2):
+                raise ValidationError(
+                    message="Overlapping areas are not supported.",
+                    status_code=400,
+                )
+        for p in shapely_polygons:
             # Check if valid (no self-intersections, no duplicate vertices,
             # minimum vertex count, no overlapping segments)
             if not p.is_valid:

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -676,6 +676,100 @@ def test_invalid_area_polygons_returns_400(
     assert response.status_code == status_code
 
 
+_ALERT_WITH_GENERATED_AREAS = """
+    <alert xmlns='urn:oasis:names:tc:emergency:cap:1.2'>
+        <identifier>c60bc14b-8411-4dd7-8d9e-0f159f79eab3</identifier>
+        <sender>broadcasts@notifications.service.gov.uk</sender>
+        <sent>2025-02-16T23:01:13-00:00</sent>
+        <status>Actual</status>
+        <msgType>Alert</msgType>
+        <scope>Public</scope>
+        <info>
+            <language>en-GB</language>
+            <category>Safety</category>
+            <event>Test Alert</event>
+            <urgency>Expected</urgency>
+            <severity>Severe</severity>
+            <certainty>Likely</certainty>
+            <expires>2025-02-17T21:31:13-00:00</expires>
+            <senderName>GOV.UK Emergency Alerts</senderName>
+            <headline>GOV.UK Emergency Alert</headline>
+            <description>Test</description>
+            {areas}
+        </info>
+    </alert>
+"""
+
+
+def _cap_xml_with_polygons(polygon_strings):
+    areas = "".join(
+        f"<area><areaDesc>area</areaDesc><polygon>{polygon}</polygon></area>" for polygon in polygon_strings
+    )
+    return _ALERT_WITH_GENERATED_AREAS.format(areas=areas)
+
+
+def test_too_many_polygons_is_rejected_before_geometry_work(client, sample_broadcast_service, mocker):
+    # Each polygon is a tiny valid 4-point ring; the request is rejected purely
+    # for exceeding the polygon-count ceiling, before any Polygons/Shapely work.
+    max_polygons = client.application.config["MAX_BROADCAST_POLYGON_COUNT"]
+    polygons_spy = mocker.patch("app.v2.broadcast.post_broadcast.Polygons")
+
+    square = "0,50 0.1,50 0.1,50.1 0,50"
+    cap_xml = _cap_xml_with_polygons([square] * (max_polygons + 1))
+
+    auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
+    response = client.post(
+        path="/v2/broadcast",
+        data=cap_xml,
+        headers=[("Content-Type", "application/cap+xml"), auth_header],
+    )
+
+    assert response.status_code == 400
+    assert response.json["errors"][0]["message"] == (
+        f"Too many polygons ({max_polygons + 1}); the maximum is {max_polygons}"
+    )
+    # The cheap count check must short-circuit before we construct any geometry.
+    polygons_spy.assert_not_called()
+
+
+def test_too_many_points_is_rejected_before_geometry_work(client, sample_broadcast_service, mocker):
+    max_points = client.application.config["MAX_BROADCAST_POLYGON_POINT_COUNT"]
+    polygons_spy = mocker.patch("app.v2.broadcast.post_broadcast.Polygons")
+
+    # A single polygon whose point count exceeds the ceiling.
+    huge_polygon = " ".join(f"{i / 100000},50" for i in range(max_points + 1))
+    cap_xml = _cap_xml_with_polygons([huge_polygon])
+
+    auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
+    response = client.post(
+        path="/v2/broadcast",
+        data=cap_xml,
+        headers=[("Content-Type", "application/cap+xml"), auth_header],
+    )
+
+    assert response.status_code == 400
+    assert response.json["errors"][0]["message"] == (
+        f"Too many coordinates ({max_points + 1}); the maximum is {max_points}"
+    )
+    polygons_spy.assert_not_called()
+
+
+def test_oversized_request_body_is_rejected_with_413(client, sample_broadcast_service):
+    # A body larger than MAX_CONTENT_LENGTH is refused by Flask before the route
+    # (and therefore before any XML parsing) runs.
+    max_content_length = client.application.config["MAX_CONTENT_LENGTH"]
+    oversized_body = b"<alert>" + b"a" * (max_content_length + 1)
+
+    auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
+    response = client.post(
+        path="/v2/broadcast",
+        data=oversized_body,
+        headers=[("Content-Type", "application/cap+xml"), auth_header],
+    )
+
+    assert response.status_code == 413
+
+
 def test_request_for_status_returns_allowed_methods(client, sample_broadcast_service):
     auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
     response = client.options(

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -755,9 +755,9 @@ def test_too_many_points_is_rejected_before_geometry_work(client, sample_broadca
 
 
 def test_oversized_request_body_is_rejected_with_413(client, sample_broadcast_service):
-    # A body larger than MAX_CONTENT_LENGTH is refused by Flask before the route
+    # A body larger than MAX_CONTENT_SIZE is refused by Flask before the route
     # (and therefore before any XML parsing) runs.
-    max_content_length = client.application.config["MAX_CONTENT_LENGTH"]
+    max_content_length = client.application.config["MAX_CONTENT_SIZE"]
     oversized_body = b"<alert>" + b"a" * (max_content_length + 1)
 
     auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)

--- a/tests/app/v2/broadcast/test_post_broadcast.py
+++ b/tests/app/v2/broadcast/test_post_broadcast.py
@@ -777,11 +777,13 @@ def test_too_many_points_is_rejected_before_geometry_work(client, sample_broadca
     polygons_spy.assert_not_called()
 
 
-def test_oversized_request_body_is_rejected_with_413(client, sample_broadcast_service):
-    # A body larger than MAX_CONTENT_SIZE is refused by Flask before the route
-    # (and therefore before any XML parsing) runs.
-    max_content_length = client.application.config["MAX_CONTENT_SIZE"]
-    oversized_body = b"<alert>" + b"a" * (max_content_length + 1)
+def test_oversized_request_body_is_rejected_with_400(client, sample_broadcast_service, mocker):
+    # A body larger than MAX_BROADCASTS_XML_LENGTH is rejected in validate_xml
+    # before the document is parsed against the schema. Override the limit to a
+    # small value so we don't have to allocate a 65MB payload in the test.
+    mocker.patch.dict(client.application.config, {"MAX_BROADCASTS_XML_LENGTH": 100})
+    max_length = client.application.config["MAX_BROADCASTS_XML_LENGTH"]
+    oversized_body = b"<alert>" + b"a" * (max_length + 1)
 
     auth_header = create_service_authorization_header(service_id=sample_broadcast_service.id)
     response = client.post(
@@ -790,7 +792,10 @@ def test_oversized_request_body_is_rejected_with_413(client, sample_broadcast_se
         headers=[("Content-Type", "application/cap+xml"), auth_header],
     )
 
-    assert response.status_code == 413
+    assert response.status_code == 400
+    assert response.json["errors"][0]["message"] == (
+        f"Request data is not valid CAP XML: XML must be {max_length} characters or fewer"
+    )
 
 
 def test_request_for_status_returns_allowed_methods(client, sample_broadcast_service):


### PR DESCRIPTION
A DoS attack could craft an oversized payload (polygon area definition) that would hit compute/memory limits on the API instances. To limit the polygon complexity, this PR adds hard limits on the polygon count and the polygon-point count.