### PR TITLE
EAS-3163 Reduce metadata exposure and stop DB & CW calls on healthcheck

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -243,6 +243,12 @@ def init_app(app):
         response.headers.add("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE")
         response.headers.add("Strict-Transport-Security", "max-age=63072000; includeSubdomains; preload")
         response.headers.add("Referrer-Policy", "no-referrer")
+        # Suppress server/version fingerprinting. Overriding (not deleting) is required: the
+        # Werkzeug dev server only injects its own "Server: Werkzeug/x Python/y" default when the
+        # response has no Server header, so popping it would let that default come back.
+        response.headers["Server"] = "eas-api"
+        response.headers.pop("X-B3-TraceId", None)
+        response.headers.pop("X-B3-SpanId", None)
         return response
 
     @app.after_request

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -1,22 +1,32 @@
 import boto3
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 
 from app import current_app, db, version
+from app.authentication.auth import requires_admin_auth
 from app.dao.organisation_dao import dao_count_organisations_with_live_services
 from app.dao.services_dao import dao_count_live_services
+from app.errors import register_errors
 
 status = Blueprint("status", __name__)
+
+register_errors(status)
 
 
 @status.route("/", methods=["GET"])
 @status.route("/_api_status", methods=["GET", "POST"])
-def show_api_status():
-    if request.args.get("simple", None):
-        return jsonify(status="ok"), 200  # cheap liveness probe: no DB, no CloudWatch
+def fast_api_status():
+    # Unauthenticated liveness probe used by load balancers / uptime checks: no DB, no metadata.
+    return jsonify(status="ok"), 200  # This should be considered part of the public API
 
+
+@status.route("/_api_status/full", methods=["GET"])
+def full_api_status():
+    # Full status exposes build/version/schema metadata, so it is restricted to authenticated
+    # internal callers (e.g. the admin app). The status blueprint is otherwise unauthenticated.
+    requires_admin_auth()
     return (
         jsonify(
-            status="ok",  # This should be considered part of the public API
+            status="ok",
             git_commit=version.git_commit,
             build_time=version.time,
             db_version=get_db_version(),

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -14,15 +14,12 @@ def show_api_status():
     if request.args.get("simple", None):
         return jsonify(status="ok"), 200  # cheap liveness probe: no DB, no CloudWatch
 
-    post_app_version_to_cloudwatch()
-    db_version = get_db_version()
-    post_db_version_to_cloudwatch(db_version)
     return (
         jsonify(
             status="ok",  # This should be considered part of the public API
             git_commit=version.git_commit,
             build_time=version.time,
-            db_version=db_version,
+            db_version=get_db_version(),
             app_version=version.app_version,
         ),
         200,

--- a/app/status/healthcheck.py
+++ b/app/status/healthcheck.py
@@ -11,23 +11,22 @@ status = Blueprint("status", __name__)
 @status.route("/", methods=["GET"])
 @status.route("/_api_status", methods=["GET", "POST"])
 def show_api_status():
+    if request.args.get("simple", None):
+        return jsonify(status="ok"), 200  # cheap liveness probe: no DB, no CloudWatch
+
     post_app_version_to_cloudwatch()
     db_version = get_db_version()
     post_db_version_to_cloudwatch(db_version)
-
-    if request.args.get("simple", None):
-        return jsonify(status="ok"), 200
-    else:
-        return (
-            jsonify(
-                status="ok",  # This should be considered part of the public API
-                git_commit=version.git_commit,
-                build_time=version.time,
-                db_version=db_version,
-                app_version=version.app_version,
-            ),
-            200,
-        )
+    return (
+        jsonify(
+            status="ok",  # This should be considered part of the public API
+            git_commit=version.git_commit,
+            build_time=version.time,
+            db_version=db_version,
+            app_version=version.app_version,
+        ),
+        200,
+    )
 
 
 @status.route("/_api_status/live-service-and-organisation-counts")

--- a/tests/app/status/test_status.py
+++ b/tests/app/status/test_status.py
@@ -1,6 +1,5 @@
 import os
 
-import boto3
 import pytest
 from flask import json
 
@@ -24,18 +23,6 @@ def test_get_status_all_ok(mocked_aws, client, notify_db_session, notify_api, pa
     assert resp_json["db_version"] == db_version
     assert resp_json["git_commit"]
     assert resp_json["build_time"]
-
-    cloudwatch = boto3.client("cloudwatch", region_name=aws_region)
-    app_metric = cloudwatch.list_metrics()["Metrics"][0]
-    assert app_metric["MetricName"] == "AppVersion"
-    assert app_metric["Namespace"] == "Emergency Alerts"
-    assert {"Name": "Application", "Value": service} in app_metric["Dimensions"]
-
-    db_metric = cloudwatch.list_metrics()["Metrics"][1]
-    assert db_metric["MetricName"] == "DBVersion"
-    assert db_metric["Namespace"] == "Emergency Alerts"
-    assert {"Name": "Application", "Value": service} in db_metric["Dimensions"]
-    assert {"Name": "Version", "Value": db_version} in db_metric["Dimensions"]
 
 
 def test_empty_live_service_and_organisation_counts(admin_request):

--- a/tests/app/status/test_status.py
+++ b/tests/app/status/test_status.py
@@ -4,25 +4,34 @@ import pytest
 from flask import json
 
 from tests.app.db import create_organisation, create_service
-from tests.conftest import set_config
 
 aws_region = os.environ.get("AWS_REGION", "eu-west-2")
 
 
 @pytest.mark.parametrize("path", ["/", "/_api_status"])
-def test_get_status_all_ok(mocked_aws, client, notify_db_session, notify_api, path):
-    service = "api"
-    with set_config(notify_api, "SERVICE", service):
-        response = client.get(path)
-
-    db_version = notify_db_session.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+def test_fast_status_returns_ok_only(client, notify_api, path):
+    response = client.get(path)
 
     assert response.status_code == 200
-    resp_json = json.loads(response.get_data(as_text=True))
+    assert json.loads(response.get_data(as_text=True)) == {"status": "ok"}
+
+
+def test_full_status_requires_authentication(client, notify_api):
+    response = client.get("/_api_status/full")
+
+    assert response.status_code == 401
+
+
+def test_full_status_returns_metadata_when_authenticated(admin_request, notify_db_session, notify_api):
+    db_version = notify_db_session.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+
+    resp_json = admin_request.get("status.full_api_status")
+
     assert resp_json["status"] == "ok"
     assert resp_json["db_version"] == db_version
     assert resp_json["git_commit"]
     assert resp_json["build_time"]
+    assert "app_version" in resp_json
 
 
 def test_empty_live_service_and_organisation_counts(admin_request):


### PR DESCRIPTION
- Stop "Server" metadata exposing the server and framework.
- Stop posting database and app version to CloudWatch on each status call; these CW updates are done by the `run_health_check` periodic task that runs every minute.
- There are now two distinct status endpoints, a fast unauthenticated route and the full status route returning app and db version data in the payload.