### PR TITLE
EAS-3120: Remove broadcast message `content` escaping

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -201,7 +201,6 @@ def create_broadcast_message(service_id):
             + (" (because it could not be GSM7 encoded)" if temporary_template.non_gsm_characters else ""),
             status_code=400,
         )
-    content = str(temporary_template)
     reference = data["reference"]
 
     broadcast_message = BroadcastMessage(
@@ -213,7 +212,7 @@ def create_broadcast_message(service_id):
         starts_at=_parse_nullable_datetime(data.get("starts_at")),
         finishes_at=_parse_nullable_datetime(data.get("finishes_at")),
         created_by_id=user.id,
-        content=content,
+        content=data["content"],
         reference=reference,
         stubbed=service.restricted,
     )

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -212,7 +212,7 @@ def create_broadcast_message(service_id):
         starts_at=_parse_nullable_datetime(data.get("starts_at")),
         finishes_at=_parse_nullable_datetime(data.get("finishes_at")),
         created_by_id=user.id,
-        content=data["content"], # Storing broadcast message content as raw text from posted data
+        content=data["content"],  # Storing broadcast message content as raw text from posted data
         reference=reference,
         stubbed=service.restricted,
     )

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -212,7 +212,7 @@ def create_broadcast_message(service_id):
         starts_at=_parse_nullable_datetime(data.get("starts_at")),
         finishes_at=_parse_nullable_datetime(data.get("finishes_at")),
         created_by_id=user.id,
-        content=data["content"],
+        content=data["content"], # Storing broadcast message content as raw text from posted data
         reference=reference,
         stubbed=service.restricted,
     )

--- a/app/broadcast_message/utils.py
+++ b/app/broadcast_message/utils.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from emergency_alerts_utils.clients.zendesk.zendesk_client import (
     EASSupportTicket,
 )
+from emergency_alerts_utils.template import BroadcastMessageTemplate
 from emergency_alerts_utils.xml.common import SENDER
 from flask import current_app
 from jinja2 import Environment, FileSystemLoader
@@ -118,6 +119,9 @@ def _create_broadcast_event(broadcast_message):
     database, and triggers the task to send the CAP XML off.
     """
     service = broadcast_message.service
+    # `content` is stored in the DB as raw text, so it needs to be sanitised before being used in a BroadcastEvent
+    # Previously done during alert creation; that logic has now been moved here
+    content = str(BroadcastMessageTemplate.from_content(broadcast_message.content))
 
     if not broadcast_message.stubbed and not service.restricted:
         msg_types = {
@@ -128,7 +132,7 @@ def _create_broadcast_event(broadcast_message):
             service=service,
             broadcast_message=broadcast_message,
             message_type=msg_types[broadcast_message.status],
-            transmitted_content={"body": broadcast_message.content},
+            transmitted_content={"body": content},
             transmitted_areas=broadcast_message.areas,
             transmitted_sender=SENDER,
             # TODO: Should this be set to now? Or the original starts_at?

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -329,7 +329,7 @@ def test_create_broadcast_message(admin_request, sample_broadcast_service, train
         "ids": ["manchester"],
         "simple_polygons": [[[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]]],
     }
-    assert response["content"] == "Some content\n€ŷŵ~\n''\"\"---"
+    assert response["content"] == "Some content\r\n€ŷŵ~\r\n‘’“”—–-"
 
     broadcast_message = dao_get_broadcast_message_by_id_and_service_id(response["id"], sample_broadcast_service.id)
     assert broadcast_message.stubbed == training_mode_service
@@ -431,7 +431,7 @@ def test_create_broadcast_message_can_be_created_from_content(admin_request, sam
         service_id=sample_broadcast_service.id,
         _expected_status=201,
     )
-    assert response["content"] == "Some content\n€ŷŵ~\n''\"\"---"
+    assert response["content"] == "Some content\r\n€ŷŵ~\r\n‘’“”—–-"
     assert response["reference"] == "abc123"
     assert response["template_id"] is None
     assert response["cap_event"] is None

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -424,7 +424,6 @@ def test_create_broadcast_message_400s_if_content_too_long(
         ("Some content\r\n€ŷŵ~\r\n‘’“”—–-"),
         ("Hello <b>World</b>"),
         ("Emergency & Alerts & Service"),
-
     ),
 )
 @freeze_time("2020-01-01")

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -418,12 +418,21 @@ def test_create_broadcast_message_400s_if_content_too_long(
     assert response.get("message") == expected_errors
 
 
+@pytest.mark.parametrize(
+    "content",
+    (
+        ("Some content\r\n€ŷŵ~\r\n‘’“”—–-"),
+        ("Hello <b>World</b>"),
+        ("Emergency & Alerts & Service"),
+
+    ),
+)
 @freeze_time("2020-01-01")
-def test_create_broadcast_message_can_be_created_from_content(admin_request, sample_broadcast_service):
+def test_create_broadcast_message_can_be_created_from_content(admin_request, sample_broadcast_service, content):
     response = admin_request.post(
         "broadcast_message.create_broadcast_message",
         _data={
-            "content": "Some content\r\n€ŷŵ~\r\n‘’“”—–-",
+            "content": content,
             "reference": "abc123",
             "service_id": str(sample_broadcast_service.id),
             "created_by": str(sample_broadcast_service.created_by_id),
@@ -431,7 +440,8 @@ def test_create_broadcast_message_can_be_created_from_content(admin_request, sam
         service_id=sample_broadcast_service.id,
         _expected_status=201,
     )
-    assert response["content"] == "Some content\r\n€ŷŵ~\r\n‘’“”—–-"
+    # broadcast message content stored exactly as in posted data, no escaping
+    assert response["content"] == content
     assert response["reference"] == "abc123"
     assert response["template_id"] is None
     assert response["cap_event"] is None

--- a/tests/app/broadcast_message/test_utils.py
+++ b/tests/app/broadcast_message/test_utils.py
@@ -333,6 +333,38 @@ def test_update_broadcast_message_status_creates_event_with_correct_content_if_b
     assert alert_event.transmitted_content == {"body": "tailor made emergency broadcast content"}
 
 
+@pytest.mark.parametrize(
+    "content, expected_content",
+    [
+        ("Test Alert", "Test Alert"),
+        ("Some content\r\n€ŷŵ~\r\n‘’“”—–-", 'Some content\n€ŷŵ~\n\'\'""---'),
+        ("Hello <b>World</b>", "Hello &lt;b&gt;World&lt;/b&gt;"),
+        ("Emergency & Alerts & Service", "Emergency &amp; Alerts &amp; Service"),
+    ],
+)
+def test_update_broadcast_message_status_creates_broadcast_event_with_sanitised_content(
+    sample_broadcast_service, mocker, content, expected_content
+):
+    broadcast_message = create_broadcast_message(
+        service=sample_broadcast_service,
+        content=content,
+        status=BroadcastStatusType.PENDING_APPROVAL,
+        areas={"ids": ["london"], "simple_polygons": [[[51.30, 0.7], [51.28, 0.8], [51.25, -0.7]]]},
+    )
+    approver = create_user(email="approver@gov.uk")
+    sample_broadcast_service.users.append(approver)
+    mock_task = mocker.patch("app.tasks.broadcast_message_tasks.send_broadcast_event.send")
+
+    update_broadcast_message_status(broadcast_message, BroadcastStatusType.BROADCASTING, approver)
+
+    assert len(broadcast_message.events) == 1
+    alert_event = broadcast_message.events[0]
+
+    mock_task.assert_called_once_with(broadcast_event_id=str(alert_event.id))
+
+    assert alert_event.transmitted_content == {"body": expected_content}
+
+
 def test_update_broadcast_message_status_creates_zendesk_ticket(mocker, notify_api, sample_broadcast_service):
     broadcast_message = create_broadcast_message(
         service=sample_broadcast_service,

--- a/tests/app/broadcast_message/test_utils.py
+++ b/tests/app/broadcast_message/test_utils.py
@@ -337,7 +337,7 @@ def test_update_broadcast_message_status_creates_event_with_correct_content_if_b
     "content, expected_content",
     [
         ("Test Alert", "Test Alert"),
-        ("Some content\r\n€ŷŵ~\r\n‘’“”—–-", 'Some content\n€ŷŵ~\n\'\'""---'),
+        ("Some content\r\n€ŷŵ~\r\n‘’“”—–-", "Some content\n€ŷŵ~\n''\"\"---"),
         ("Hello <b>World</b>", "Hello &lt;b&gt;World&lt;/b&gt;"),
         ("Emergency & Alerts & Service", "Emergency &amp; Alerts &amp; Service"),
     ],


### PR DESCRIPTION
In this PR I removed the sanitisation when storing broadcast message `content` in DB, but have instead moved it to `_create_broadcast_event` function as this is still necessary for `broadcast_event` creation.
I've also added a relevant test and adjusted existing.

NOTE: This can only be merged once govuk PR, regarding sanitisation pre-render of content, is deployed.