### PR TITLE
Fix/Use UTC datetimes in publish-checks comparison

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1475,12 +1475,12 @@ class PublishTaskProgress(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     task_id = db.Column(db.String, index=True, unique=False, nullable=False)
     last_published_file = db.Column(db.String, nullable=True)
-    started_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.now())
+    started_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     last_activity_at = db.Column(
         db.DateTime,
         nullable=True,
-        onupdate=datetime.datetime.now(),
-        default=datetime.datetime.now(),
+        onupdate=datetime.datetime.utcnow,
+        default=datetime.datetime.utcnow,
     )
     finished_at = db.Column(db.DateTime, nullable=True)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1477,10 +1477,7 @@ class PublishTaskProgress(db.Model):
     last_published_file = db.Column(db.String, nullable=True)
     started_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
     last_activity_at = db.Column(
-        db.DateTime,
-        nullable=True,
-        onupdate=datetime.datetime.utcnow,
-        default=datetime.datetime.utcnow,
+        db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow, default=datetime.datetime.utcnow
     )
     finished_at = db.Column(db.DateTime, nullable=True)
 

--- a/app/models.py
+++ b/app/models.py
@@ -1475,9 +1475,12 @@ class PublishTaskProgress(db.Model):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     task_id = db.Column(db.String, index=True, unique=False, nullable=False)
     last_published_file = db.Column(db.String, nullable=True)
-    started_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.utcnow)
+    started_at = db.Column(db.DateTime, nullable=False, default=datetime.datetime.now())
     last_activity_at = db.Column(
-        db.DateTime, nullable=True, onupdate=datetime.datetime.utcnow, default=datetime.datetime.utcnow
+        db.DateTime,
+        nullable=True,
+        onupdate=datetime.datetime.now(),
+        default=datetime.datetime.now(),
     )
     finished_at = db.Column(db.DateTime, nullable=True)
 

--- a/app/publish_task_progress/rest.py
+++ b/app/publish_task_progress/rest.py
@@ -1,4 +1,4 @@
-from time import time
+from datetime import datetime
 
 from flask import Blueprint, current_app, jsonify, request
 
@@ -58,7 +58,7 @@ def finish_publish():
 
 @publish_task_progress_blueprint.route("/get-publish-tasks", methods=["GET"])
 def get_publish_tasks():
-    now = time()
+    now = datetime.utcnow().timestamp()
     tasks = dao_get_all_in_progress_publish_tasks()
 
     result = {}

--- a/tests/app/tasks/test_scheduled_tasks.py
+++ b/tests/app/tasks/test_scheduled_tasks.py
@@ -1,6 +1,6 @@
 import time
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import call
 
 import pytest
@@ -185,7 +185,8 @@ def test_validate_functional_test_account_emails(notify_db_session):
     notify_db_session.add(user2)
     notify_db_session.commit()
 
-    now = datetime.now()
+    # UTC datetime but email_access_validated_at is offset-naive so remove TZ info
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     time.sleep(1)
 
     validate_functional_test_account_emails()


### PR DESCRIPTION
This PR resolves the timezone issues in unit tests by replacing `now` timestamp for comparison and references in tests to UTC datetime.