### PR TITLE
EAS-3211: Fix adding status and retrying if Dramatiq raises TimeLimitExceeded

### DIFF
--- a/app/tasks/broadcast_message_tasks.py
+++ b/app/tasks/broadcast_message_tasks.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+from dramatiq.threading import Interrupt
 from emergency_alerts_utils.tasks import QueueNames, TaskNames
 from emergency_alerts_utils.xml.common import HEADLINE
 from flask import current_app
@@ -144,7 +145,7 @@ def send_broadcast_event(broadcast_event_id):
     actor_name=TaskNames.SEND_BROADCAST_PROVIDER_MESSAGE,
     queue_name=QueueNames.HIGH_PRIORITY,
     allow_retry=True,
-    retry_for=CBCProxyRetryableException,
+    retry_for={CBCProxyRetryableException, Interrupt},
 )
 # Note: Adjusting the args? You may need to edit DlqWatcher accordingly
 def send_broadcast_provider_message(*, broadcast_event_id, provider):
@@ -232,7 +233,9 @@ def send_broadcast_provider_message(*, broadcast_event_id, provider):
                 )
 
         add_broadcast_provider_message_status(broadcast_provider_message, status=BROADCAST_PROVIDER_STATUS_ACK)
-    except Exception as e:
+    except (Exception, Interrupt) as e:
+        # Interrupt is from Dramatiq, and does not inherit from Exception
+
         exception_detail = getattr(e, "message", repr(e))
 
         current_app.logger.exception(

--- a/tests/app/tasks/test_broadcast_message_tasks.py
+++ b/tests/app/tasks/test_broadcast_message_tasks.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from unittest.mock import ANY, Mock, call
 
 import pytest
+from dramatiq.middleware.time_limit import TimeLimitExceeded
+from dramatiq.threading import Interrupt
 from freezegun import freeze_time
 
 from app.clients.cbc_proxy import CBCProxyRetryableException
@@ -456,8 +458,15 @@ def test_send_broadcast_provider_message_sends_cancel_with_references(
         ["vodafone", "Vodafone"],
     ],
 )
+@pytest.mark.parametrize(
+    "exception_type, exception_detail",
+    [
+        (CBCProxyRetryableException("test"), "CBCProxyRetryableException('test')"),
+        (TimeLimitExceeded("test"), "TimeLimitExceeded('test')"),
+    ],
+)
 def test_send_broadcast_provider_message_error_statuses_are_saved(
-    mocker, sample_broadcast_service, provider, provider_capitalised
+    mocker, sample_broadcast_service, provider, provider_capitalised, exception_type, exception_detail
 ):
     template = create_template(sample_broadcast_service, BROADCAST_TYPE)
 
@@ -476,15 +485,15 @@ def test_send_broadcast_provider_message_error_statuses_are_saved(
 
     mock_create_broadcast = mocker.patch(
         f"app.clients.cbc_proxy.CBCProxy{provider_capitalised}.create_and_send_broadcast",
-        side_effect=CBCProxyRetryableException("oh no"),
+        side_effect=exception_type,
     )
 
     # The retry logic here is based around the idea we should bubble exceptions where appropriate
-    # and that the actor is registered for retry (for SqsRetryMiddleware to handle)
+    # and that the Dramatiq actor is registered for retry (for SqsRetryMiddleware to handle)
     assert send_broadcast_provider_message.kw.get("allow_retry")
-    assert send_broadcast_provider_message.kw.get("retry_for") == CBCProxyRetryableException
+    assert send_broadcast_provider_message.kw.get("retry_for") == {CBCProxyRetryableException, Interrupt}
 
-    with pytest.raises(CBCProxyRetryableException):
+    with pytest.raises(type(exception_type)):
         send_broadcast_provider_message(provider=provider, broadcast_event_id=str(event.id))
 
     mock_create_broadcast.assert_called_once_with(
@@ -510,7 +519,7 @@ def test_send_broadcast_provider_message_error_statuses_are_saved(
     assert len(broadcast_provider_message.statuses) == 2
     assert broadcast_provider_message.statuses[0].status == BROADCAST_PROVIDER_STATUS_SENDING
     assert broadcast_provider_message.statuses[1].status == BROADCAST_PROVIDER_STATUS_ERR
-    assert broadcast_provider_message.statuses[1].error_detail == {"exception": "CBCProxyRetryableException('oh no')"}
+    assert broadcast_provider_message.statuses[1].error_detail == {"exception": exception_detail}
     assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
 


### PR DESCRIPTION
> Requires https://github.com/alphagov/emergency-alerts-utils/pull/184

This should resolve a scenario where the task itself doesn't outright fail, but gets caught by Dramatiq's TimeLimit middleware. In this scenario the task thread is forcibly raised into an exception state and raises TimeLimitExceeded. This _doesn't_ inherit from Exception and so wasn't caught here, and resulted in the strange behaviour of us not recording a status as the code intended.

In addition we now allow such a thing to retry/redeliver with a tweak to the middleware in utils.

`utils:bugfix/eas-3211-utils-retry_for-multiple`