### PR TITLE
EAS-3028: Area functionality migration version, adds `geographic_id` & `name_singular` columns

### DIFF
--- a/migrations/versions/0430_adjust_area_tables.py
+++ b/migrations/versions/0430_adjust_area_tables.py
@@ -1,0 +1,144 @@
+"""
+
+Revision ID: 0430_adjust_area_tables
+Revises: 0429_unescape_message_content
+Create Date: 2026-08-05 14:22:30
+
+"""
+
+import uuid
+
+from geoalchemy2 import Geometry
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0430_adjust_area_tables"
+down_revision = "0429_unescape_message_content"
+
+
+def upgrade():
+    # Clearing all existing data to add the new column
+    op.execute("DELETE FROM geography_polygons")
+    op.execute("DELETE FROM geography_version")
+    op.execute("DELETE FROM geography_type")
+
+    op.add_column("geography_type", sa.Column("name_singular", sa.Text(), nullable=True))
+
+    op.drop_table("geography_polygons")
+
+    op.create_table(
+        "geography_polygons",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False, unique=True, default=uuid.uuid4),
+        sa.Column("geographic_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),
+        sa.Column("parent_geography_id", sa.String(), nullable=True),
+        sa.Column("geography_version_id", sa.String(), nullable=False),
+        # Stored for optimisation purposes - not strictly necessary as we can retrieve
+        # geography_type_id from geography_version relation in first instance
+        sa.Column("geography_type_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["geography_version_id"],
+            ["geography_version.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["geography_type_id"],
+            ["geography_type.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_geography_polygons_id",
+        "geography_polygons",
+        ["id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geographic_id",
+        "geography_polygons",
+        ["geographic_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_name",
+        "geography_polygons",
+        ["name"],
+    )
+    op.create_index(
+        "ix_geography_polygons_parent_geography_id",
+        "geography_polygons",
+        ["parent_geography_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_version_id",
+        "geography_polygons",
+        ["geography_version_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_type_id",
+        "geography_polygons",
+        ["geography_type_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geometry",
+        "geography_polygons",
+        ["geometry"],
+        postgresql_using="gist",
+    )
+
+
+def downgrade():
+    # Dropping everything related to geography_polygons table before we re-add with adjustments
+    op.drop_column("geography_type", "name_singular")
+    op.drop_table("geography_polygons")
+
+    op.create_table(
+        "geography_polygons",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),
+        sa.Column("parent_geography_id", sa.String(), nullable=True),
+        sa.Column("geography_version_id", sa.String(), nullable=False),
+        # Stored for optimisation purposes - not strictly necessary as we can retrieve
+        # geography_type_id from geography_version relation in first instance
+        sa.Column("geography_type_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["geography_version_id"],
+            ["geography_version.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["geography_type_id"],
+            ["geography_type.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_geography_polygons_id",
+        "geography_polygons",
+        ["id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_name",
+        "geography_polygons",
+        ["name"],
+    )
+    op.create_index(
+        "ix_geography_polygons_parent_geography_id",
+        "geography_polygons",
+        ["parent_geography_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_version_id",
+        "geography_polygons",
+        ["geography_version_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_type_id",
+        "geography_polygons",
+        ["geography_type_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geometry",
+        "geography_polygons",
+        ["geometry"],
+        postgresql_using="gist",
+    )

--- a/migrations/versions/0431_adjust_area_tables.py
+++ b/migrations/versions/0431_adjust_area_tables.py
@@ -30,6 +30,7 @@ def upgrade():
     op.create_table(
         "geography_polygons",
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False, unique=True, default=uuid.uuid4),
+        #  Office for National Statistics (ONS) and Government Statistical Service (GSS) code for the area e.g. England's is E92000001
         sa.Column("geographic_id", sa.String(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),

--- a/migrations/versions/0431_adjust_area_tables.py
+++ b/migrations/versions/0431_adjust_area_tables.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0430_adjust_area_tables
-Revises: 0429_unescape_message_content
+Revision ID: 0431_adjust_area_tables.py
+Revises: 0430_add_bpm_err_retry_exhausted
 Create Date: 2026-08-05 14:22:30
 
 """
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision = "0430_adjust_area_tables"
-down_revision = "0429_unescape_message_content"
+revision = "0431_adjust_area_tables.py"
+down_revision = "0430_add_bpm_err_retry_exhausted"
 
 
 def upgrade():

--- a/migrations/versions/0431_adjust_area_tables.py
+++ b/migrations/versions/0431_adjust_area_tables.py
@@ -8,9 +8,9 @@ Create Date: 2026-08-05 14:22:30
 
 import uuid
 
-from geoalchemy2 import Geometry
 import sqlalchemy as sa
 from alembic import op
+from geoalchemy2 import Geometry
 from sqlalchemy.dialects import postgresql
 
 revision = "0431_adjust_area_tables.py"
@@ -23,6 +23,7 @@ def upgrade():
     op.execute("DELETE FROM geography_version")
     op.execute("DELETE FROM geography_type")
 
+    # How a single area from this library is referred to in Admin application
     op.add_column("geography_type", sa.Column("name_singular", sa.Text(), nullable=True))
 
     op.drop_table("geography_polygons")


### PR DESCRIPTION
This PR adds a migration that, on upgrade:
1. Deletes all data from the area tables
2. Adds `name_singular` column to `geography_type` table
3. Drops the `geography_polygons` table & relevant indexes 
4. Recreates `geography_polygons` & indexes with geographic_id column added

`name_singular` column required for displaying libraries in Admin application, addition of `geographic_id` allows us to store geometries with unique ID as primary key, but still stores their ONS/GSS identifier.