### PR TITLE
EAS-3028: Addition of area functionality, using DB stored areas

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -95,6 +95,7 @@ def create_app(application):
 
 def register_blueprint(application):
     from app.admin_action.rest import admin_action_blueprint
+    from app.areas.rest import areas_blueprint
     from app.authentication.auth import (
         requires_admin_auth,
         requires_govuk_alerts_auth,
@@ -133,6 +134,9 @@ def register_blueprint(application):
 
     admin_action_blueprint.before_request(requires_admin_auth)
     application.register_blueprint(admin_action_blueprint, url_prefix="/admin-action")
+
+    areas_blueprint.before_request(requires_admin_auth)
+    application.register_blueprint(areas_blueprint)
 
     service_blueprint.before_request(requires_admin_auth)
     application.register_blueprint(service_blueprint, url_prefix="/service")

--- a/app/areas/rest.py
+++ b/app/areas/rest.py
@@ -4,10 +4,6 @@ from flask import Blueprint, jsonify, request
 from geoalchemy2.shape import to_shape
 
 from app.areas.utils import (
-    COORDINATES,
-    FLOOD_WARNING_AREAS,
-    LOCAL_AUTHORITIES,
-    POSTCODES,
     add_custom_area_to_existing_areas,
     area_response_json,
     build_circle_area,
@@ -107,10 +103,10 @@ def get_areas():
     legacy_ids = []  # IDs starting with legacy_prefixes
 
     for area_id in area_ids:
-        if area_id.startswith(POSTCODES):
-            circle_ids.append((area_id, POSTCODES))
-        elif area_id.startswith(COORDINATES):
-            circle_ids.append((area_id, COORDINATES))
+        if area_id.startswith("postcodes"):
+            circle_ids.append((area_id, "postcodes"))
+        elif area_id.startswith("coordinates"):
+            circle_ids.append((area_id, "coordinates"))
         elif area_id.startswith(legacy_prefixes):
             legacy_ids.append(area_id)
         else:
@@ -211,7 +207,7 @@ def get_postcode_centroid():
     data = request.get_json() or {}
     postcode = data.get("postcode")
 
-    postcode_area = dao_get_latest_area_by_geographic_id(postcode, POSTCODES)
+    postcode_area = dao_get_latest_area_by_geographic_id(postcode, "postcodes")
     if not postcode_area:
         return jsonify({"message": "Enter a postcode within the UK"}), 400
 
@@ -262,7 +258,7 @@ def get_areas_by_names(type_name):
     for name in area_names:
         if name not in found_by_name:
             message = (
-                f"Local authority '{name}' not found" if type_name == LOCAL_AUTHORITIES else error_messages["invalid"]
+                f"Local authority '{name}' not found" if type_name == "local_authorities" else error_messages["invalid"]
             )
             return jsonify({"message": message}), 400
 
@@ -279,7 +275,7 @@ def create_postcode_area():
     postcode = data.get("postcode")
     if not radius or not postcode:
         return jsonify({"message": "Enter postcode and radius to create postcode area"}), 400
-    postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, POSTCODES).id
+    postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, "postcodes").id
     centroid = dao_get_area_centroid(postcode_area_id)
     circle = dao_create_circle_area(centroid, radius)
     centroid_wkt = shapely.wkt.loads(centroid)
@@ -348,9 +344,9 @@ def build_alert_area_for_ids():
 
     # Splits specified area IDs into appropriate lists, to be processed accordingly
     for area_id in area_ids:
-        if area_id.startswith(POSTCODES):
+        if area_id.startswith("postcodes"):
             postcode_ids.append(area_id)
-        elif area_id.startswith(COORDINATES):
+        elif area_id.startswith("coordinates"):
             coordinate_ids.append(area_id)
         else:
             predefined_area_ids.append(area_id)
@@ -447,7 +443,7 @@ def add_areas(service_id, message_id, message_type):
         error_messages = bulk_input_error_messages_by_geography_type(type_name)
 
         flood_warning_area_ids = area_ids
-        if type_name == FLOOD_WARNING_AREAS:
+        if type_name == "flood_warning_areas":
             flood_warning_area_ids, error_response, status = process_flood_warning_area_ids(
                 area_ids, existing_ids, error_messages
             )
@@ -478,7 +474,7 @@ def add_areas(service_id, message_id, message_type):
         error_messages = bulk_input_error_messages_by_geography_type(type_name)
 
         flood_ids = area_ids
-        if type_name == FLOOD_WARNING_AREAS:
+        if type_name == "flood_warning_areas":
             flood_ids, error_response, status = process_flood_warning_area_ids(area_ids, existing_ids, error_messages)
             if error_response:
                 return error_response, status

--- a/app/areas/rest.py
+++ b/app/areas/rest.py
@@ -1,0 +1,603 @@
+import shapely
+from emergency_alerts_utils.polygons import Polygons
+from flask import Blueprint, jsonify, request
+from geoalchemy2.shape import to_shape
+
+from app.areas.utils import (
+    add_custom_area_to_existing_areas,
+    area_response_json,
+    build_circle_area,
+    build_remaining_area_wkt,
+    bulk_input_error_messages_by_geography_type,
+    create_alert_area_dict,
+    ensure_valid_wkt,
+    generate_centroid_for_coordinate_area,
+    generate_coordinate_area_name,
+    get_existing_area_data,
+    parse_coordinate_id,
+    parse_postcode_id,
+    validate_bulk_area_input,
+)
+from app.dao.areas_dao import (
+    dao_check_coordinates_valid,
+    dao_combine_geometries,
+    dao_create_area,
+    dao_create_circle_area,
+    dao_get_area_by_id,
+    dao_get_area_centroid,
+    dao_get_areas_by_ids,
+    dao_get_areas_by_names,
+    dao_get_areas_for_geography_type,
+    dao_get_child_areas_for_parent_geography_id,
+    dao_get_grandparent_areas,
+    dao_get_latest_area_by_geographic_id,
+    dao_get_latest_geography_types_with_count_and_examples,
+)
+from app.dao.broadcast_message_dao import (
+    dao_get_broadcast_message_by_id_and_service_id,
+)
+from app.dao.broadcast_message_history_dao import (
+    dao_create_broadcast_message_version,
+)
+from app.dao.dao_utils import dao_save_object
+from app.dao.templates_dao import (
+    dao_get_template_by_id_and_service_id,
+    dao_update_template,
+)
+from app.schemas import template_schema
+
+areas_blueprint = Blueprint(
+    "areas",
+    __name__,
+    url_prefix="/areas",
+)
+
+
+@areas_blueprint.route("/<area_id>", methods=["GET"])
+def get_area(area_id):
+    """
+    Retrieves area from area ID.
+    """
+    result = dao_get_area_by_id(area_id)
+    if result is None:
+        return jsonify({"message": "No area with this ID"}), 400
+    data = area_response_json(result)
+
+    return jsonify({"data": data})
+
+
+@areas_blueprint.route("/geographic_id/<geographic_id>", methods=["GET"])
+def get_area_by_geographic_id_endpoint(geographic_id):
+    """
+    Returns the latest area for a certain geographic ID.
+    """
+    result = dao_get_latest_area_by_geographic_id(geographic_id)
+    if result is None:
+        return jsonify({"message": "No area retrieved for this geographic ID."}), 400
+
+    data = area_response_json(result)
+
+    return jsonify({"data": data})
+
+
+@areas_blueprint.route("/get-areas", methods=["POST"])
+def get_areas():
+    data = request.get_json() or {}
+    area_ids = data.get("area_ids") or []
+    area_names = data.get("area_names") or []
+
+    # Areas from alerts, created prior to this change, will have area IDs that we don't store
+    legacy_prefixes = (
+        "ctry19-",
+        "Flood_Warning_Target_Areas-",
+        "wd25-",
+        "test-",
+        "lad25-",
+        "ctyua25-",
+    )
+
+    id_to_name = dict(zip(area_ids, area_names))
+
+    predefined_area_ids = []
+    circle_ids = []  # Postcode and Coordinate areas that we generate ourselves, from IDs
+    legacy_ids = []  # IDs starting with legacy_prefixes
+
+    for area_id in area_ids:
+        if area_id.startswith("postcodes"):
+            circle_ids.append((area_id, "postcodes"))
+        elif area_id.startswith("coordinates"):
+            circle_ids.append((area_id, "coordinates"))
+        elif area_id.startswith(legacy_prefixes):
+            legacy_ids.append(area_id)
+        else:
+            # If not circle (postcode or coordinate areas) or legacy, then
+            # we assume it is an area we have predefined in geography_polygona
+            predefined_area_ids.append(area_id)
+
+    data = []
+
+    if predefined_area_ids:
+        predefined_results = dao_get_areas_by_ids(predefined_area_ids)
+        data.extend(area_response_json(row) for row in predefined_results)
+
+    for legacy_id in legacy_ids:
+        # Removes legacy prefix and uses the remainder (geographic ID) to source area
+        _, geographic_id = legacy_id.split("-", 1)
+        row = dao_get_latest_area_by_geographic_id(geographic_id)
+        if row is None:
+            return jsonify({"message": "No area could be found for this geographic ID"}), 400
+        data.append(area_response_json(row))
+
+    # Generate postcode and coordinate areas to be stored
+    for area_id, geography_type in circle_ids:
+        data.append(build_circle_area(area_id, geography_type, id_to_name))
+
+    return jsonify({"data": data})
+
+
+@areas_blueprint.route("/<area_id>/is-grandparent", methods=["GET"])
+def is_grandparent(area_id):
+    """Returns bool for whether or not an area is a grandparent area, i.e.
+    is a parent of an area that is also a parent"""
+    grandparent_areas = [str(i[0]) for i in dao_get_grandparent_areas()]
+    return jsonify({"data": area_id in grandparent_areas})
+
+
+@areas_blueprint.route("/geography-types", methods=["GET"])
+def get_geography_types_and_examples():
+    """Returns a list of geography types/libraries (dicts), for rendering in Admin application"""
+    results = dao_get_latest_geography_types_with_count_and_examples()
+    data = []
+
+    for row in results:
+        # For each geography type (library)
+        area_names = list(row.areas or [])  # Geography type's areas
+        count = int(row.area_count or 0)  # Count of areas for geography type
+
+        # Generates examples string to be displayed on Admin
+        # applications 'libraries' page
+        if count <= 4:
+            examples = ", ".join(area_names)
+        else:
+            shown = area_names[:3]
+            remaining = count - 3
+            examples = f"{', '.join(shown)} and {remaining} more..."
+
+        data.append(
+            {
+                "id": row.id,
+                "name": row.geography_type_name,
+                "name_singular": row.name_singular,
+                "route": row.route,
+                "examples": examples,
+            }
+        )
+
+    return jsonify({"data": data})
+
+
+@areas_blueprint.route("/geography-types/<type_name>/areas", methods=["GET"])
+def get_areas_for_type(type_name):
+    """Returns list of areas for a geography type/library"""
+    results = dao_get_areas_for_geography_type(type_name)
+    areas = [
+        {"id": row.id, "geographic_id": row.geographic_id, "name": row.name, "parent": row.parent_geography_id}
+        for row in results
+    ]
+    return jsonify({"data": areas})
+
+
+@areas_blueprint.route("/<parent_geography_id>/sub-areas", methods=["GET"])
+def get_child_areas_for_parent(parent_geography_id):
+    """Returns list of areas with specified parent_geography_id"""
+    results = dao_get_child_areas_for_parent_geography_id(parent_geography_id)
+    areas = [
+        {"id": row.id, "geographic_id": row.geographic_id, "name": row.name, "is_parent": row.parent_geography_id}
+        for row in results
+    ]
+
+    return jsonify({"data": areas})
+
+
+@areas_blueprint.route("/postcodes/get-centroid", methods=["POST"])
+def get_postcode_centroid():
+    """
+    Returns the centroid WKT for the specific postcode.
+    """
+    data = request.get_json() or {}
+    postcode = data.get("postcode")
+
+    postcode_area = dao_get_latest_area_by_geographic_id(postcode, "postcodes")
+    if not postcode_area:
+        return jsonify({"message": "Enter a postcode within the UK"}), 400
+
+    centroid = dao_get_area_centroid(postcode_area.id)
+    if centroid is None:
+        return jsonify({"message": "Area has no geometry"}), 400
+
+    return jsonify({"data": centroid})
+
+
+@areas_blueprint.route("/coordinates/get-centroid", methods=["POST"])
+def get_coordinates_centroid():
+    """
+    Returns a centroid WKT for the provided coordinates.
+    """
+    data = request.get_json() or {}
+    first_coordinate = data.get("first_coordinate")
+    second_coordinate = data.get("second_coordinate")
+    coordinate_type = data.get("coordinate_type")
+
+    if not dao_check_coordinates_valid(first_coordinate, second_coordinate, coordinate_type):
+        return jsonify({"message": "Enter coordinates within the UK"}), 400
+
+    centroid = generate_centroid_for_coordinate_area(first_coordinate, second_coordinate, coordinate_type)
+
+    return jsonify({"data": centroid})
+
+
+@areas_blueprint.route("/get-<type_name>-by-names", methods=["POST"])
+def get_local_authorities_areas_by_names(type_name):
+    """Returns a list of areas that have the names provided for the provided type,
+    or error response with custom error messages set for local_authorities areas."""
+    data = request.get_json() or {}
+    area_names = data.get("area_names") or []
+
+    # Filters possible error messages by geography type
+    error_messages = bulk_input_error_messages_by_geography_type(type_name)
+
+    if error_response := validate_bulk_area_input(area_names, type_name):
+        return jsonify({"message": error_response}), 400
+
+    areas = dao_get_areas_by_names(area_names, type_name)
+    found_by_name = {area.name: area.id for area in areas}
+
+    # Returns 400 error for a missing name - error to then be
+    # rendered as is in Admin application
+    for name in area_names:
+        if name not in found_by_name:
+            return (
+                jsonify(
+                    {
+                        "message": error_messages["invalid"],
+                        "missing_area_name": name,
+                        "geography_type": type_name,
+                    }
+                ),
+                400,
+            )
+
+    ids = [found_by_name[name] for name in area_names]
+    return jsonify({"data": ids})
+
+
+@areas_blueprint.route("/postcode-area", methods=["POST"])
+def create_postcode_area():
+    """Returns WKT string of created postcode area, created using radius and
+    centroid of the latest polygon for the specified postcode boundary"""
+    data = request.get_json()
+    radius = data.get("radius")
+    postcode = data.get("postcode")
+    postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, "postcodes").id
+    centroid = dao_get_area_centroid(postcode_area_id)
+    circle = dao_create_circle_area(centroid, radius)
+    centroid_wkt = shapely.wkt.loads(centroid)
+    id = f"postcodes_{centroid_wkt.x}_{centroid_wkt.y}_{radius}_{postcode}"
+    return jsonify({"circle": circle, "id": id})
+
+
+@areas_blueprint.route("/coordinate-area", methods=["POST"])
+def create_coordinate_area():
+    """Returns WKT string of created coordinate area, created using radius and
+    centroid, formed from specified coordinates"""
+    data = request.get_json()
+    first_coordinate = data.get("first_coordinate")
+    second_coordinate = data.get("second_coordinate")
+    coordinate_type = data.get("coordinate_type")
+    radius = float(data.get("radius"))
+
+    if not dao_check_coordinates_valid(first_coordinate, second_coordinate, coordinate_type):
+        return jsonify({"message": "Enter coordinates within the UK"}), 400
+
+    centroid = generate_centroid_for_coordinate_area(first_coordinate, second_coordinate, coordinate_type)
+    circle = dao_create_circle_area(centroid, radius)
+    return jsonify(
+        {
+            "data": circle,
+        }
+    )
+
+
+@areas_blueprint.route("/check-coordinates-valid", methods=["POST"])
+def check_coordinates_valid():
+    """Returns boolean result of whether or not the specified
+    coordinates lie within UK polygon area"""
+    data = request.get_json()
+    first = data.get("first_coordinate")
+    second = data.get("second_coordinate")
+    coordinate_type = data.get("coordinate_type")
+    valid = dao_check_coordinates_valid(first, second, coordinate_type)
+    return jsonify(
+        {
+            "data": valid,
+        }
+    )
+
+
+@areas_blueprint.route("/get-area-dict", methods=["POST"])
+def build_alert_area_for_ids():
+    """
+    Returns area dictionary for an alert, based on specified area IDs.
+    Names are sourced from the database for predefined areas and
+    generated for postcode/coordinate areas.
+    """
+    data = request.get_json() or {}
+    area_ids = data.get("area_ids") or []
+
+    if not area_ids:
+        # If no area IDs, return empty area dictionary
+        return (
+            jsonify(create_alert_area_dict()),
+            200,
+        )
+
+    predefined_area_ids = []
+    postcode_ids = []
+    coordinate_ids = []
+
+    # Splits specified area IDs into appropriate lists, to be processed accordingly
+    for area_id in area_ids:
+        if area_id.startswith("postcodes"):
+            postcode_ids.append(area_id)
+        elif area_id.startswith("coordinates"):
+            coordinate_ids.append(area_id)
+        else:
+            predefined_area_ids.append(area_id)
+
+    geometries_wkt = []
+    names = []
+
+    # For predefined areas, source area polygons and append to list of geometries
+    if predefined_area_ids:
+        predefined_areas = dao_get_areas_by_ids(set(predefined_area_ids))
+        geometries_wkt.extend([to_shape(a.geometry).wkt for a in predefined_areas])
+        names.extend([a.name for a in predefined_areas])
+
+    for postcode_id in postcode_ids:
+        # Split the postcode ID into centroid coordinates and radius of area
+        x, y, radius, postcode = parse_postcode_id(postcode_id)
+        centroid = shapely.Point(x, y).wkt
+        circle_wkt = dao_create_circle_area(centroid, radius)
+        geometries_wkt.append(circle_wkt)
+        names.append(f"{radius}km around the postcode {postcode}")
+
+    for coordinate_id in coordinate_ids:
+        # Split the coordinate ID into centroid coordinates and radius of area
+        x, y, radius, coordinate_type = parse_coordinate_id(coordinate_id)
+        centroid = generate_centroid_for_coordinate_area(x, y, coordinate_type)
+        name = generate_coordinate_area_name(x, y, radius, coordinate_type)
+        circle_wkt = dao_create_circle_area(centroid, radius)
+        geometries_wkt.append(circle_wkt)
+        names.append(name)
+
+    # Combine all of the geometries then validate the combined WKT
+    combined_wkt = dao_create_area(geometries_wkt)
+    combined_wkt = ensure_valid_wkt(combined_wkt)
+
+    # From WKT, Polygons object (from emergency-alerts-utils) returned
+    polygons = Polygons.from_wkt(combined_wkt, utm_crs="EPSG:4326")
+    alert_area = create_alert_area_dict(area_ids, names, polygons.polygons)
+    return jsonify(alert_area), 200
+
+
+@areas_blueprint.route("/<service_id>/<message_id>/<message_type>/add-areas", methods=["POST"])
+def add_areas(service_id, message_id, message_type):
+    data = request.get_json() or {}
+    area_ids = data.get("area_ids") or []
+    type_name = data.get("type_name")
+
+    # The following are inner functions that have been extracted as they are called at
+    # least once for both broadcast messages and templates
+    def process_flood_warning_area_ids(raw_ids, existing_ids, error_messages):
+        # Flood Warning Area ID input validation and if valid, they are appended to alert areas
+        if error_response := validate_bulk_area_input(raw_ids, type_name):
+            return None, jsonify({"message": error_response}), 400
+
+        sourced_ids = []
+        for original_id in raw_ids:
+            area = dao_get_latest_area_by_geographic_id(original_id)
+            if area is None:
+                return None, jsonify({"message": error_messages["invalid"]}), 400
+
+            area_id = str(area.id)
+            if area_id in existing_ids:
+                return None, jsonify({"message": error_messages["already_selected"]}), 400
+
+            sourced_ids.append(area_id)
+
+        return sourced_ids, None, None
+
+    def build_combined_alert_area(existing_ids, existing_names, existing_polygons, new_area_ids):
+        # Combines the existing areas and the new areas, by sourcing the WKT for
+        # each new area and combining with existing alert area WKT
+        areas = dao_get_areas_by_ids(set(new_area_ids))
+        names = [area.name for area in areas]
+        new_area_wkts = [to_shape(area.geometry).wkt for area in areas]
+        new_areas_combined_wkt = dao_create_area(new_area_wkts)
+
+        # Reversed as utils requires the area polygons to be long, lat NOT lat, long
+        reversed_polygons = [[[coord[1], coord[0]] for coord in polygon] for polygon in existing_polygons]
+        existing_wkt = Polygons(polygons=reversed_polygons).as_wkt
+
+        combined_wkt = dao_combine_geometries(existing_wkt, new_areas_combined_wkt)
+        combined_wkt = ensure_valid_wkt(combined_wkt)
+
+        polygons = Polygons.from_wkt(combined_wkt, utm_crs="EPSG:4326")
+
+        combined_ids = existing_ids + new_area_ids
+        combined_names = existing_names + names
+        return create_alert_area_dict(combined_ids, combined_names, polygons.polygons)
+
+    def add_areas_to_broadcast_message():
+        broadcast_message = dao_get_broadcast_message_by_id_and_service_id(message_id, service_id)
+        existing_ids, existing_names, existing_polygons = get_existing_area_data(broadcast_message)
+
+        # Sources the error messages for rendering if bulk area input invalid
+        error_messages = bulk_input_error_messages_by_geography_type(type_name)
+
+        flood_warning_area_ids = area_ids
+        if type_name == "flood_warning_areas":
+            flood_warning_area_ids, error_response, status = process_flood_warning_area_ids(
+                area_ids, existing_ids, error_messages
+            )
+            if error_response:
+                return error_response, status
+
+        # Areas to be added are only those predefined that are not already added to alert
+        areas_to_be_added = [area for area in (flood_warning_area_ids or area_ids) if area not in existing_ids]
+        if not areas_to_be_added:
+            return jsonify(broadcast_message.serialize()), 200
+
+        alert_area = build_combined_alert_area(existing_ids, existing_names, existing_polygons, areas_to_be_added)
+        broadcast_message.areas = alert_area
+
+        dao_save_object(broadcast_message)
+        dao_create_broadcast_message_version(
+            broadcast_message,
+            service_id,
+            broadcast_message.updated_by_id,
+        )
+        return jsonify(broadcast_message.serialize()), 200
+
+    def add_areas_to_template():
+        template = dao_get_template_by_id_and_service_id(message_id, service_id)
+        existing_ids, existing_names, existing_polygons = get_existing_area_data(template)
+
+        # Sources the error messages for rendering if bulk area input invalid
+        error_messages = bulk_input_error_messages_by_geography_type(type_name)
+
+        flood_ids = area_ids
+        if type_name == "flood_warning_areas":
+            flood_ids, error_response, status = process_flood_warning_area_ids(area_ids, existing_ids, error_messages)
+            if error_response:
+                return error_response, status
+
+        # Areas to be added are only those predefined that are not already added to alert
+        areas_to_be_added = [area for area in (flood_ids or area_ids) if area not in existing_ids]
+        if not areas_to_be_added:
+            return jsonify(template_schema.dump(template)), 200
+
+        alert_area = build_combined_alert_area(existing_ids, existing_names, existing_polygons, areas_to_be_added)
+
+        current_data = dict(template_schema.dump(template).items())
+        updated_template_data = dict(current_data)
+        updated_template_data["areas"] = alert_area
+
+        update_dict = template_schema.load(updated_template_data)
+        if update_dict.archived:
+            update_dict.folder = None
+
+        dao_update_template(update_dict)
+        return jsonify(data=template_schema.dump(update_dict)), 200
+
+    if message_type == "broadcast":
+        return add_areas_to_broadcast_message()
+    elif message_type == "templates":
+        return add_areas_to_template()
+
+
+@areas_blueprint.route("/<service_id>/<message_id>/<message_type>/add-<type_name>-area", methods=["POST"])
+def add_custom_areas(service_id, message_id, message_type, type_name):
+    """Uses specified custom area IDS, parses based on `type_name`,
+    creates the custom area and adds to the broadcast_message or template"""
+    data = request.get_json() or {}
+
+    def add_custom_areas_to_broadcast_message(service_id, message_id, type_name, data):
+        broadcast_message = dao_get_broadcast_message_by_id_and_service_id(message_id, service_id)
+        updated_message, error_response, status = add_custom_area_to_existing_areas(broadcast_message, type_name, data)
+        if error_response:
+            return error_response, status
+
+        dao_save_object(updated_message)
+        dao_create_broadcast_message_version(
+            updated_message,
+            service_id,
+            updated_message.updated_by_id,
+        )
+        return jsonify(updated_message.serialize()), 200
+
+    def add_custom_areas_to_template(service_id, template_id, type_name, data):
+        template = dao_get_template_by_id_and_service_id(template_id, service_id)
+
+        updated_template, error_response, status = add_custom_area_to_existing_areas(template, type_name, data)
+        if error_response:
+            return error_response, status
+
+        # Save updated template
+        dao_save_object(updated_template)
+
+        # Build an updated_template dict like update_template does,
+        # using the updated template and its new areas data
+        current_data = dict(template_schema.dump(updated_template).items())
+        alert_area = updated_template.areas or {}
+        current_data["areas"] = alert_area
+
+        update_dict = template_schema.load(current_data)
+        if update_dict.archived:
+            update_dict.folder = None
+        dao_update_template(update_dict)
+        return jsonify(template_schema.dump(update_dict)), 200
+
+    if message_type == "broadcast":
+        return add_custom_areas_to_broadcast_message(service_id, message_id, type_name, data)
+    elif message_type == "templates":
+        return add_custom_areas_to_template(service_id, message_id, type_name, data)
+
+    return jsonify({"message": "Unsupported message_type"}), 400
+
+
+@areas_blueprint.route("/<service_id>/<message_id>/<message_type>/remove-area", methods=["POST"])
+def remove_area(service_id, message_id, message_type):
+    """Identifies the area IDs remaining once specified area IDs are removed,
+    then with these calculates the remaining area for the alert"""
+    data = request.get_json() or {}
+    area_id_to_remove = data.get("area_id") or []
+
+    def build_remaining_alert_areas(area_id_to_remove, existing_ids, existing_names):
+        new_ids, new_polygons, any_remaining = build_remaining_area_wkt(existing_ids, area_id_to_remove)
+        if not any_remaining:
+            return create_alert_area_dict()
+
+        new_names = [name for id, name in zip(existing_ids, existing_names) if id != area_id_to_remove]
+        return create_alert_area_dict(new_ids, new_names, new_polygons)
+
+    if message_type == "broadcast":
+        broadcast_message = dao_get_broadcast_message_by_id_and_service_id(message_id, service_id)
+        existing_ids, existing_names, existing_polygons = get_existing_area_data(broadcast_message)
+
+        broadcast_message.areas = build_remaining_alert_areas(area_id_to_remove, existing_ids, existing_names)
+
+        dao_save_object(broadcast_message)
+        dao_create_broadcast_message_version(
+            broadcast_message,
+            service_id,
+            broadcast_message.updated_by_id,
+        )
+        return jsonify(broadcast_message.serialize()), 200
+
+    elif message_type == "templates":
+        template = dao_get_template_by_id_and_service_id(message_id, service_id)
+        existing_ids, existing_names, existing_polygons = get_existing_area_data(template)
+
+        alert_area = build_remaining_alert_areas(area_id_to_remove, existing_ids, existing_names)
+
+        current_data = dict(template_schema.dump(template).items())
+        updated_template_data = dict(current_data)
+        updated_template_data["areas"] = alert_area
+
+        update_dict = template_schema.load(updated_template_data)
+        if update_dict.archived:
+            update_dict.folder = None
+
+        dao_update_template(update_dict)
+        return jsonify(data=template_schema.dump(update_dict)), 200

--- a/app/areas/rest.py
+++ b/app/areas/rest.py
@@ -221,7 +221,7 @@ def get_postcode_centroid():
 @areas_blueprint.route("/coordinates/get-centroid", methods=["POST"])
 def get_coordinates_centroid():
     """
-    Returns a centroid WKT for the provided coordinates.
+    Returns a centroid WKT for the provided coordinates, in latitude longitude.
     """
     data = request.get_json() or {}
     first_coordinate = data.get("first_coordinate")
@@ -237,9 +237,10 @@ def get_coordinates_centroid():
 
 
 @areas_blueprint.route("/get-<type_name>-by-names", methods=["POST"])
-def get_local_authorities_areas_by_names(type_name):
+def get_areas_by_names(type_name):
     """Returns a list of areas that have the names provided for the provided type,
-    or error response with custom error messages set for local_authorities areas."""
+    or error response with custom error messages set for local_authorities
+    and flood_warning_areas areas."""
     data = request.get_json() or {}
     area_names = data.get("area_names") or []
 
@@ -256,16 +257,10 @@ def get_local_authorities_areas_by_names(type_name):
     # rendered as is in Admin application
     for name in area_names:
         if name not in found_by_name:
-            return (
-                jsonify(
-                    {
-                        "message": error_messages["invalid"],
-                        "missing_area_name": name,
-                        "geography_type": type_name,
-                    }
-                ),
-                400,
+            message = (
+                f"Local authority '{name}' not found" if type_name == "local_authorities" else error_messages["invalid"]
             )
+            return jsonify({"message": message}), 400
 
     ids = [found_by_name[name] for name in area_names]
     return jsonify({"data": ids})
@@ -278,6 +273,8 @@ def create_postcode_area():
     data = request.get_json()
     radius = data.get("radius")
     postcode = data.get("postcode")
+    if not radius or not postcode:
+        return jsonify({"message": "Enter postcode and radius to create postcode area"}), 400
     postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, "postcodes").id
     centroid = dao_get_area_centroid(postcode_area_id)
     circle = dao_create_circle_area(centroid, radius)

--- a/app/areas/rest.py
+++ b/app/areas/rest.py
@@ -4,6 +4,10 @@ from flask import Blueprint, jsonify, request
 from geoalchemy2.shape import to_shape
 
 from app.areas.utils import (
+    COORDINATES,
+    FLOOD_WARNING_AREAS,
+    LOCAL_AUTHORITIES,
+    POSTCODES,
     add_custom_area_to_existing_areas,
     area_response_json,
     build_circle_area,
@@ -103,10 +107,10 @@ def get_areas():
     legacy_ids = []  # IDs starting with legacy_prefixes
 
     for area_id in area_ids:
-        if area_id.startswith("postcodes"):
-            circle_ids.append((area_id, "postcodes"))
-        elif area_id.startswith("coordinates"):
-            circle_ids.append((area_id, "coordinates"))
+        if area_id.startswith(POSTCODES):
+            circle_ids.append((area_id, POSTCODES))
+        elif area_id.startswith(COORDINATES):
+            circle_ids.append((area_id, COORDINATES))
         elif area_id.startswith(legacy_prefixes):
             legacy_ids.append(area_id)
         else:
@@ -207,7 +211,7 @@ def get_postcode_centroid():
     data = request.get_json() or {}
     postcode = data.get("postcode")
 
-    postcode_area = dao_get_latest_area_by_geographic_id(postcode, "postcodes")
+    postcode_area = dao_get_latest_area_by_geographic_id(postcode, POSTCODES)
     if not postcode_area:
         return jsonify({"message": "Enter a postcode within the UK"}), 400
 
@@ -258,7 +262,7 @@ def get_areas_by_names(type_name):
     for name in area_names:
         if name not in found_by_name:
             message = (
-                f"Local authority '{name}' not found" if type_name == "local_authorities" else error_messages["invalid"]
+                f"Local authority '{name}' not found" if type_name == LOCAL_AUTHORITIES else error_messages["invalid"]
             )
             return jsonify({"message": message}), 400
 
@@ -275,7 +279,7 @@ def create_postcode_area():
     postcode = data.get("postcode")
     if not radius or not postcode:
         return jsonify({"message": "Enter postcode and radius to create postcode area"}), 400
-    postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, "postcodes").id
+    postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, POSTCODES).id
     centroid = dao_get_area_centroid(postcode_area_id)
     circle = dao_create_circle_area(centroid, radius)
     centroid_wkt = shapely.wkt.loads(centroid)
@@ -344,9 +348,9 @@ def build_alert_area_for_ids():
 
     # Splits specified area IDs into appropriate lists, to be processed accordingly
     for area_id in area_ids:
-        if area_id.startswith("postcodes"):
+        if area_id.startswith(POSTCODES):
             postcode_ids.append(area_id)
-        elif area_id.startswith("coordinates"):
+        elif area_id.startswith(COORDINATES):
             coordinate_ids.append(area_id)
         else:
             predefined_area_ids.append(area_id)
@@ -443,7 +447,7 @@ def add_areas(service_id, message_id, message_type):
         error_messages = bulk_input_error_messages_by_geography_type(type_name)
 
         flood_warning_area_ids = area_ids
-        if type_name == "flood_warning_areas":
+        if type_name == FLOOD_WARNING_AREAS:
             flood_warning_area_ids, error_response, status = process_flood_warning_area_ids(
                 area_ids, existing_ids, error_messages
             )
@@ -474,7 +478,7 @@ def add_areas(service_id, message_id, message_type):
         error_messages = bulk_input_error_messages_by_geography_type(type_name)
 
         flood_ids = area_ids
-        if type_name == "flood_warning_areas":
+        if type_name == FLOOD_WARNING_AREAS:
             flood_ids, error_response, status = process_flood_warning_area_ids(area_ids, existing_ids, error_messages)
             if error_response:
                 return error_response, status

--- a/app/areas/utils.py
+++ b/app/areas/utils.py
@@ -15,17 +15,6 @@ from app.dao.areas_dao import (
     dao_get_latest_area_by_geographic_id,
 )
 
-# Geography types and their respective routes,
-# set here and referenced to ensure consistency
-LOCAL_AUTHORITIES = "local_authorities"
-WARDS = "wards"
-REPPIR_SITES = "reppir_sites"
-TEST = "test"
-FLOOD_WARNING_AREAS = "flood_warning_areas"
-COUNTRIES = "countries"
-POSTCODES = "postcodes"
-COORDINATES = "coordinates"
-
 
 def area_response_json(area_object):
     return {
@@ -73,7 +62,7 @@ def build_circle_area(area_id, geography_type, id_to_name):
     }
 
 
-def get_parent_geography_id(area_wkt, parent_type_name=LOCAL_AUTHORITIES):
+def get_parent_geography_id(area_wkt, parent_type_name="local_authorities"):
     """Retrieves the parent geography ID either from DB, if exists, or by
     calculating the most intersecting area from areas with specified type"""
     return dao_get_dominant_parent_geography_id(area_wkt, parent_type_name)
@@ -88,15 +77,15 @@ def add_custom_area_to_existing_areas(message, type_name, data):
     existing_ids, existing_names, existing_polygons = get_existing_area_data(message)
 
     # Build centroid, area_id and name based on type
-    if type_name == POSTCODES:
+    if type_name == "postcodes":
         postcode = data.get("postcode")
-        postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, POSTCODES).id
+        postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, "postcodes").id
         centroid = dao_get_area_centroid(postcode_area_id)
         centroid_wkt = shapely.wkt.loads(centroid)
         area_id = f"postcodes_{centroid_wkt.x}_{centroid_wkt.y}_{radius}_{postcode}"
         name = f"{radius:g}km around the postcode {postcode}"
 
-    elif type_name == COORDINATES:
+    elif type_name == "coordinates":
         first_coordinate = data.get("first_coordinate")
         second_coordinate = data.get("second_coordinate")
         coordinate_type = data.get("coordinate_type")
@@ -179,7 +168,7 @@ def bulk_input_error_messages_by_geography_type(type_name):
     """
     Stored error messages for bulk area input by type_name.
     """
-    if type_name == FLOOD_WARNING_AREAS:
+    if type_name == "flood_warning_areas":
         return {
             "missing_data": "Enter at least 1 Flood Warning TA code",
             "duplicates": "All Flood Warning TA codes must be unique",
@@ -187,7 +176,7 @@ def bulk_input_error_messages_by_geography_type(type_name):
             "exceeds_limit": "Maximum of 25 TA codes in an emergency alert",
             "already_selected": "Flood Warning TA code already selected",
         }
-    elif type_name == LOCAL_AUTHORITIES:
+    elif type_name == "local_authorities":
         return {
             "missing_data": "Enter at least 1 local authority",
             "duplicates": "All local authorities must be unique",
@@ -256,13 +245,14 @@ def build_remaining_area_wkt(existing_ids, area_id_to_remove):
     remaining_ids = [
         area_id
         for area_id in existing_ids
-        if area_id != area_id_to_remove and (not area_id.startswith(POSTCODES) and not area_id.startswith(COORDINATES))
+        if area_id != area_id_to_remove
+        and (not area_id.startswith("postcodes") and not area_id.startswith("coordinates"))
     ]
     remaining_postcode_ids = [
-        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith(POSTCODES)
+        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith("postcodes")
     ]
     remaining_coordinates_ids = [
-        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith(COORDINATES)
+        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith("coordinates")
     ]
 
     if not remaining_ids and not remaining_postcode_ids and not remaining_coordinates_ids:

--- a/app/areas/utils.py
+++ b/app/areas/utils.py
@@ -15,6 +15,17 @@ from app.dao.areas_dao import (
     dao_get_latest_area_by_geographic_id,
 )
 
+# Geography types and their respective routes,
+# set here and referenced to ensure consistency
+LOCAL_AUTHORITIES = "local_authorities"
+WARDS = "wards"
+REPPIR_SITES = "reppir_sites"
+TEST = "test"
+FLOOD_WARNING_AREAS = "flood_warning_areas"
+COUNTRIES = "countries"
+POSTCODES = "postcodes"
+COORDINATES = "coordinates"
+
 
 def area_response_json(area_object):
     return {
@@ -62,7 +73,7 @@ def build_circle_area(area_id, geography_type, id_to_name):
     }
 
 
-def get_parent_geography_id(area_wkt, parent_type_name="local_authorities"):
+def get_parent_geography_id(area_wkt, parent_type_name=LOCAL_AUTHORITIES):
     """Retrieves the parent geography ID either from DB, if exists, or by
     calculating the most intersecting area from areas with specified type"""
     return dao_get_dominant_parent_geography_id(area_wkt, parent_type_name)
@@ -77,15 +88,15 @@ def add_custom_area_to_existing_areas(message, type_name, data):
     existing_ids, existing_names, existing_polygons = get_existing_area_data(message)
 
     # Build centroid, area_id and name based on type
-    if type_name == "postcodes":
+    if type_name == POSTCODES:
         postcode = data.get("postcode")
-        postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, "postcodes").id
+        postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, POSTCODES).id
         centroid = dao_get_area_centroid(postcode_area_id)
         centroid_wkt = shapely.wkt.loads(centroid)
         area_id = f"postcodes_{centroid_wkt.x}_{centroid_wkt.y}_{radius}_{postcode}"
         name = f"{radius:g}km around the postcode {postcode}"
 
-    elif type_name == "coordinates":
+    elif type_name == COORDINATES:
         first_coordinate = data.get("first_coordinate")
         second_coordinate = data.get("second_coordinate")
         coordinate_type = data.get("coordinate_type")
@@ -168,7 +179,7 @@ def bulk_input_error_messages_by_geography_type(type_name):
     """
     Stored error messages for bulk area input by type_name.
     """
-    if type_name == "flood_warning_areas":
+    if type_name == FLOOD_WARNING_AREAS:
         return {
             "missing_data": "Enter at least 1 Flood Warning TA code",
             "duplicates": "All Flood Warning TA codes must be unique",
@@ -176,7 +187,7 @@ def bulk_input_error_messages_by_geography_type(type_name):
             "exceeds_limit": "Maximum of 25 TA codes in an emergency alert",
             "already_selected": "Flood Warning TA code already selected",
         }
-    elif type_name == "local_authorities":
+    elif type_name == LOCAL_AUTHORITIES:
         return {
             "missing_data": "Enter at least 1 local authority",
             "duplicates": "All local authorities must be unique",
@@ -245,14 +256,13 @@ def build_remaining_area_wkt(existing_ids, area_id_to_remove):
     remaining_ids = [
         area_id
         for area_id in existing_ids
-        if area_id != area_id_to_remove
-        and (not area_id.startswith("postcodes") and not area_id.startswith("coordinates"))
+        if area_id != area_id_to_remove and (not area_id.startswith(POSTCODES) and not area_id.startswith(COORDINATES))
     ]
     remaining_postcode_ids = [
-        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith("postcodes")
+        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith(POSTCODES)
     ]
     remaining_coordinates_ids = [
-        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith("coordinates")
+        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith(COORDINATES)
     ]
 
     if not remaining_ids and not remaining_postcode_ids and not remaining_coordinates_ids:

--- a/app/areas/utils.py
+++ b/app/areas/utils.py
@@ -1,0 +1,288 @@
+import shapely
+from emergency_alerts_utils.polygons import Polygons
+from flask import jsonify
+from geoalchemy2.shape import to_shape
+from pyproj import Transformer
+
+from app.dao.areas_dao import (
+    dao_combine_geometries,
+    dao_create_area,
+    dao_create_circle_area,
+    dao_get_area_by_id,
+    dao_get_area_centroid,
+    dao_get_areas_by_ids,
+    dao_get_dominant_parent_geography_id,
+    dao_get_latest_area_by_geographic_id,
+)
+
+
+def area_response_json(area_object):
+    return {
+        "id": area_object.id,
+        "name": area_object.name,
+        "parent": area_object.parent_geography_id,
+        "geographic_id": area_object.geographic_id,
+        "geography_type": area_object.geography_type_name,
+    }
+
+
+def generate_coordinate_area_name(x, y, radius, coordinate_type):
+    if coordinate_type == "latitude_longitude":
+        name = f"{radius:g}km around {x} latitude, {y} longitude"
+    elif coordinate_type == "easting_northing":
+        name = f"{radius:g}km around {x} easting, {y} northing"
+    return name
+
+
+def parse_coordinate_id(area_id):
+    """Coordinate area IDs are stored in the following format
+    `coordinates_{x coordinate}_{y coordinate}_{radius}_{coordinate_type}`.
+    Where the coordinate_type is either latitude_longitude or eastings_northing
+    and is required to determine whether transformation is needed.
+    this function splits the ID into the following values"""
+    _, x_coordinate, y_coordinate, radius, coordinate_type = area_id.split("_", 4)
+    return float(x_coordinate), float(y_coordinate), float(radius), coordinate_type
+
+
+def parse_postcode_id(area_id):
+    """Postcode area IDs are stored in the following format
+    `postcodes_{x coordinate}_{y coordinate}_{radius}_{postcode ID}`,
+    where postcode ID is the postcode as is e.g. AB10 1AL.
+    This function splits the ID into the following values"""
+    _, x_coordinate, y_coordinate, radius, postcode = area_id.split("_", 4)
+    return float(x_coordinate), float(y_coordinate), float(radius), postcode
+
+
+def build_circle_area(area_id, geography_type, id_to_name):
+    return {
+        "id": area_id,
+        "name": id_to_name.get(area_id),
+        "geographic_id": area_id,
+        "geography_type": geography_type,
+    }
+
+
+def get_parent_geography_id(area_wkt, parent_type_name="local_authorities"):
+    """Retrieves the parent geography ID either from DB, if exists, or by
+    calculating the most intersecting area from areas with specified type"""
+    return dao_get_dominant_parent_geography_id(area_wkt, parent_type_name)
+
+
+def add_custom_area_to_existing_areas(message, type_name, data):
+    radius = float(data.get("radius")) if data.get("radius") is not None else None
+    area_id = None
+    if radius is None:
+        return None, jsonify({"message": "radius is required for circle areas"}), 400
+
+    existing_ids, existing_names, existing_polygons = get_existing_area_data(message)
+
+    # Build centroid, area_id and name based on type
+    if type_name == "postcodes":
+        postcode = data.get("postcode")
+        postcode_area_id = dao_get_latest_area_by_geographic_id(postcode, "postcodes").id
+        centroid = dao_get_area_centroid(postcode_area_id)
+        centroid_wkt = shapely.wkt.loads(centroid)
+        area_id = f"postcodes_{centroid_wkt.x}_{centroid_wkt.y}_{radius}_{postcode}"
+        name = f"{radius:g}km around the postcode {postcode}"
+
+    elif type_name == "coordinates":
+        first_coordinate = data.get("first_coordinate")
+        second_coordinate = data.get("second_coordinate")
+        coordinate_type = data.get("coordinate_type")
+        centroid = generate_centroid_for_coordinate_area(first_coordinate, second_coordinate, coordinate_type)
+        name = generate_coordinate_area_name(first_coordinate, second_coordinate, radius, coordinate_type)
+        if parent_area := get_parent_area_name(centroid):
+            name = f"{name} in {parent_area}"
+        centroid_wkt = shapely.wkt.loads(centroid)
+        area_id = f"coordinates_{centroid_wkt.y}_{centroid_wkt.x}_{radius}_{coordinate_type}"
+
+    # Prevent duplicate areas: if area_id already exists, return unchanged
+    if area_id and area_id in existing_ids:
+        return message, None, None
+
+    circle_wkt = dao_create_circle_area(centroid, radius)
+
+    reversed_polygons = [[[coord[1], coord[0]] for coord in polygon] for polygon in existing_polygons]
+    existing_wkt = Polygons(polygons=reversed_polygons).as_wkt
+
+    new_areas = dao_create_area([circle_wkt])
+    combined_wkt = dao_combine_geometries(existing_wkt, new_areas)
+    combined_wkt = ensure_valid_wkt(combined_wkt)
+
+    polygons = Polygons.from_wkt(combined_wkt, utm_crs="EPSG:4326")
+
+    combined_ids = existing_ids + [area_id]
+    combined_names = existing_names + [name]
+    alert_area = create_alert_area_dict(combined_ids, combined_names, polygons.polygons)
+
+    message.areas = alert_area
+    return message, None, None
+
+
+def get_parent_area_name(centroid):
+    """
+    Gets `parent_geography_id`, retrieves the area with this ID
+    and then appends the parent area name to the name, if called
+    """
+    parent_id = get_parent_geography_id(centroid)
+    if not parent_id:
+        return None
+    parent = dao_get_area_by_id(parent_id)
+    if not parent:
+        return None
+    name = parent.name
+    if name.endswith(", City of"):
+        return f"City of {name[:-9]}"
+    if name.endswith(", County of"):
+        return f"County of {name[:-11]}"
+
+
+def generate_centroid_for_coordinate_area(first_coordinate, second_coordinate, coordinate_type):
+    """Returns a Point geometry for given coordinates, if coordinate_type is easting_northing the
+    coordinates will first need to be transformed to the required CRS (EPSG:4326) for latitude, longitude"""
+    if coordinate_type == "latitude_longitude":
+        centroid = shapely.Point(float(second_coordinate), float(first_coordinate)).wkt
+    elif coordinate_type == "easting_northing":
+        # Transforms eastings northings to latitude and longitude for centroid query
+        transformer = Transformer.from_crs("EPSG:27700", "EPSG:4326", always_xy=True)
+        longitude, latitude = transformer.transform(first_coordinate, second_coordinate)
+        centroid = shapely.Point(float(longitude), float(latitude)).wkt
+    return centroid
+
+
+def ensure_valid_wkt(wkt):
+    """Returns valid WKT for a given WKT string, or error response if area can't be fixed."""
+    geom = shapely.wkt.loads(wkt)
+    if geom.is_valid:
+        return wkt
+    fixed_geom = geom.buffer(0)
+    if fixed_geom.is_valid:
+        return fixed_geom.wkt
+    return (
+        jsonify({"message": "Combined geometry is invalid"}),
+        400,
+    )
+
+
+def bulk_input_error_messages_by_geography_type(type_name):
+    """
+    Stored error messages for bulk area input by type_name.
+    """
+    if type_name == "flood_warning_areas":
+        return {
+            "missing_data": "Enter at least 1 Flood Warning TA code",
+            "duplicates": "All Flood Warning TA codes must be unique",
+            "invalid": "Flood Warning TA code not found",
+            "exceeds_limit": "Maximum of 25 TA codes in an emergency alert",
+            "already_selected": "Flood Warning TA code already selected",
+        }
+    elif type_name == "local_authorities":
+        return {
+            "missing_data": "Enter at least 1 local authority",
+            "duplicates": "All local authorities must be unique",
+            "invalid": "Local authority not found",
+            "exceeds_limit": "Maximum of 25 local authorities allowed as a list in one emergency alert",
+            "already_selected": "Local authority already selected",
+        }
+    else:
+        return {
+            "missing_data": "Enter at least 1 area",
+            "duplicates": "Area names must be unique",
+            "invalid": "Area not found",
+            "exceeds_limit": "You can add no more than 25 areas",
+            "already_selected": "Area already selected",
+        }
+
+
+def validate_bulk_area_input(area_names, type_name):
+    """
+    Returns error message, or None, depending on whether list of area names provided is valid or not.
+    """
+    error_messages = bulk_input_error_messages_by_geography_type(type_name)
+
+    # If no area_names posted
+    if not area_names:
+        return error_messages["missing_data"]
+
+    # If duplicate area names posted
+    if len(area_names) != len(set(area_names)):
+        return error_messages["duplicates"]
+
+    # We can't add more than 25 areas at a time for bulk input
+    if len(area_names) > 25:
+        return error_messages["exceeds_limit"]
+
+    return None
+
+
+def create_alert_area_dict(ids=None, names=None, polygons=None):
+    ids = ids or []
+    names = names or []
+    polygons = polygons or []
+
+    return {
+        "ids": ids,
+        "names": names,
+        "aggregate_names": names,
+        "simple_polygons": polygons,
+    }
+
+
+def get_existing_area_data(message):
+    """
+    Returns ids, names, and polygons for existing areas for
+    either a broadcast_message or template.
+    """
+    existing_areas = message.areas
+    existing_ids = existing_areas.get("ids") or []
+    existing_names = existing_areas.get("names") or []
+    existing_polygons = existing_areas.get("simple_polygons") or []
+    return existing_ids, existing_names, existing_polygons
+
+
+def build_remaining_area_wkt(existing_ids, area_id_to_remove):
+    """Builds the area for the specified `existing_ids`, minus the area to be removed"""
+    remaining_ids = [
+        area_id
+        for area_id in existing_ids
+        if area_id != area_id_to_remove
+        and (not area_id.startswith("postcodes") and not area_id.startswith("coordinates"))
+    ]
+    remaining_postcode_ids = [
+        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith("postcodes")
+    ]
+    remaining_coordinates_ids = [
+        area_id for area_id in existing_ids if area_id != area_id_to_remove and area_id.startswith("coordinates")
+    ]
+
+    if not remaining_ids and not remaining_postcode_ids and not remaining_coordinates_ids:
+        return [], [], None
+
+    remaining_areas = dao_get_areas_by_ids(set(remaining_ids))
+
+    postcode_areas = []
+    coordinate_areas = []
+
+    for postcode_id in remaining_postcode_ids:
+        x, y, radius, postcode = parse_postcode_id(postcode_id)
+        centroid = shapely.Point(x, y).wkt
+        circle_wkt = dao_create_circle_area(centroid, radius)
+        postcode_areas.append(circle_wkt)
+
+    for coordinate_id in remaining_coordinates_ids:
+        x, y, radius, coordinate_type = parse_coordinate_id(coordinate_id)
+        centroid = generate_centroid_for_coordinate_area(x, y, coordinate_type)
+        circle_wkt = dao_create_circle_area(centroid, radius)
+        coordinate_areas.append(circle_wkt)
+
+    remaining_db_wkts = [to_shape(area.geometry).wkt for area in remaining_areas]
+    circle_wkts = postcode_areas + coordinate_areas
+    remaining_wkts = remaining_db_wkts + circle_wkts
+
+    remaining_combined_wkt = dao_create_area(remaining_wkts)
+    remaining_combined_wkt = ensure_valid_wkt(remaining_combined_wkt)
+
+    polygons = Polygons.from_wkt(remaining_combined_wkt, utm_crs="EPSG:4326")
+
+    new_area_ids = [id for id in existing_ids if id != area_id_to_remove]
+    return new_area_ids, polygons.polygons, remaining_ids or remaining_postcode_ids or remaining_coordinates_ids

--- a/app/dao/areas_dao.py
+++ b/app/dao/areas_dao.py
@@ -54,6 +54,47 @@ def dao_get_areas_for_geography_type(type_name):
     return query.all()
 
 
+def dao_get_area_by_id(area_id):
+    """Returns the area, from geography_polygons, with specified area ID (UUID)"""
+    return (
+        db.session.query(
+            GeographyPolygons.id,
+            GeographyPolygons.geographic_id,
+            GeographyPolygons.name,
+            GeographyPolygons.parent_geography_id,
+            GeographyType.route.label("geography_type_name"),
+            GeographyPolygons.geometry,
+        )
+        .join(
+            GeographyType,
+            GeographyPolygons.geography_type_id == GeographyType.id,
+        )
+        .filter(GeographyPolygons.id == area_id)
+        .one_or_none()
+    )
+
+
+def dao_get_areas_by_ids(area_ids):
+    """Returns list of areas for the specified area IDs"""
+    return (
+        db.session.query(
+            GeographyPolygons.id,
+            GeographyPolygons.geographic_id,
+            GeographyPolygons.name,
+            GeographyPolygons.parent_geography_id,
+            GeographyType.route.label("geography_type_name"),
+            GeographyPolygons.geometry,
+        )
+        .join(
+            GeographyType,
+            GeographyPolygons.geography_type_id == GeographyType.id,
+        )
+        .filter(GeographyPolygons.id.in_(area_ids))
+        .order_by(GeographyPolygons.name)
+        .all()
+    )
+
+
 def dao_get_child_areas_for_parent_geography_id(parent_geography_id):
     # Only areas with latest local authority or ward version to be retrieved,
     # as these are the only child areas we are interested in currently
@@ -170,47 +211,6 @@ def dao_get_areas_by_names(area_names, type_name):
     return (
         GeographyPolygons.query.filter(GeographyPolygons.name.in_(area_names))
         .filter_by(geography_version_id=latest_version_id)
-        .all()
-    )
-
-
-def dao_get_area_by_id(area_id):
-    """Returns the area, from geography_polygons, with specified area ID (UUID)"""
-    return (
-        db.session.query(
-            GeographyPolygons.id,
-            GeographyPolygons.geographic_id,
-            GeographyPolygons.name,
-            GeographyPolygons.parent_geography_id,
-            GeographyType.route.label("geography_type_name"),
-            GeographyPolygons.geometry,
-        )
-        .join(
-            GeographyType,
-            GeographyPolygons.geography_type_id == GeographyType.id,
-        )
-        .filter(GeographyPolygons.id == area_id)
-        .one_or_none()
-    )
-
-
-def dao_get_areas_by_ids(area_ids):
-    """Returns list of areas for the specified area IDs"""
-    return (
-        db.session.query(
-            GeographyPolygons.id,
-            GeographyPolygons.geographic_id,
-            GeographyPolygons.name,
-            GeographyPolygons.parent_geography_id,
-            GeographyType.route.label("geography_type_name"),
-            GeographyPolygons.geometry,
-        )
-        .join(
-            GeographyType,
-            GeographyPolygons.geography_type_id == GeographyType.id,
-        )
-        .filter(GeographyPolygons.id.in_(area_ids))
-        .order_by(GeographyPolygons.name)
         .all()
     )
 

--- a/app/dao/areas_dao.py
+++ b/app/dao/areas_dao.py
@@ -1,0 +1,409 @@
+from geoalchemy2.shape import to_shape
+from sqlalchemy import desc, func, text
+from sqlalchemy.dialects.postgresql import aggregate_order_by
+from sqlalchemy.orm import aliased
+
+from app import db
+from app.models import GeographyPolygons, GeographyType, GeographyVersion
+
+
+def dao_get_latest_geography_version_number():
+    """Returns latest active version's version number"""
+    return GeographyVersion.query.filter_by(state="active").order_by(GeographyVersion.created_at.desc()).first().version
+
+
+def dao_get_latest_geography_versions():
+    """
+    Return the latest geography versions from  for each geography type
+    """
+    # Find the latest active version number
+    latest_version = dao_get_latest_geography_version_number()
+
+    if latest_version is None:
+        return []
+
+    return GeographyVersion.query.filter_by(state="active", version=latest_version).all()
+
+
+def dao_get_latest_active_version_for_type_route(type_name):
+    # Returns latest version for geography type
+    return (
+        db.session.query((GeographyVersion.id))
+        .join(GeographyType, GeographyVersion.geography_type_id == GeographyType.id)
+        .filter(GeographyType.route == type_name, GeographyVersion.state == "active")
+        .order_by(desc(GeographyVersion.version))
+        .first()
+    )
+
+
+def dao_get_areas_for_geography_type(type_name):
+    latest_active_version = dao_get_latest_active_version_for_type_route(type_name).id
+    query = (
+        GeographyPolygons.query.with_entities(
+            GeographyPolygons.id,
+            GeographyPolygons.geographic_id,
+            GeographyPolygons.name,
+            GeographyPolygons.parent_geography_id,
+        )
+        .filter_by(
+            geography_version_id=latest_active_version,
+        )
+        .order_by(GeographyPolygons.name)
+    )
+
+    return query.all()
+
+
+def dao_get_child_areas_for_parent_geography_id(parent_geography_id):
+    # Only areas with latest local authority or ward version to be retrieved,
+    # as these are the only child areas we are interested in currently
+    # Note: REPPIR sites also have parent_geography_id but we don't
+    # want them rendered as children for selection
+    latest_la_version_id = dao_get_latest_active_version_for_type_route("local_authorities").id
+    latest_ward_version_id = dao_get_latest_active_version_for_type_route("wards").id
+
+    version_ids = [latest_la_version_id, latest_ward_version_id]
+
+    query = (
+        GeographyPolygons.query.with_entities(
+            GeographyPolygons.id,
+            GeographyPolygons.geographic_id,
+            GeographyPolygons.name,
+            GeographyPolygons.parent_geography_id,
+        )
+        .filter(GeographyPolygons.geography_version_id.in_(version_ids))
+        .filter_by(parent_geography_id=parent_geography_id)
+        .order_by(GeographyPolygons.name)
+    )
+
+    return query.all()
+
+
+def dao_get_grandparent_areas():
+    """Returns list of areas that have child areas that are parent areas"""
+    latest_la_version_id = dao_get_latest_active_version_for_type_route("local_authorities").id
+    latest_ward_version_id = dao_get_latest_active_version_for_type_route("wards").id
+
+    version_ids = [latest_la_version_id, latest_ward_version_id]
+
+    # Use aliases of GeographyPolygons so we can join the table to itself:
+    #   GeographyPolygons = grandparent
+    #   parent_area      = child of grandparent
+    #   child_area       = child of parent_area (grandchild of grandparent)
+    parent_area = aliased(GeographyPolygons)
+    child_area = aliased(GeographyPolygons)
+
+    return (
+        db.session.query(
+            GeographyPolygons.id,  # Grandparent area IDs
+        )
+        # Finds parent areas by choosing those that are stored as parent_geography_id
+        .join(parent_area, parent_area.parent_geography_id == GeographyPolygons.geographic_id)
+        # Finds child areas of those parent areas
+        .join(child_area, child_area.parent_geography_id == parent_area.geographic_id)
+        .filter(GeographyPolygons.geography_version_id.in_(version_ids))
+        .distinct()
+        .order_by(GeographyPolygons.name)
+        .all()
+    )
+
+
+def dao_get_latest_area_by_geographic_id(area_id, type_name=None):
+    """
+    Return the latest active GeographyPolygons for a given geographic_id,
+    regardless of geography type.
+    """
+
+    if type_name:
+        latest_active_version = dao_get_latest_active_version_for_type_route(type_name)
+        return (
+            db.session.query(
+                GeographyPolygons.id,
+                GeographyPolygons.geographic_id,
+                GeographyPolygons.name,
+                GeographyPolygons.parent_geography_id,
+                GeographyType.route.label("geography_type_name"),
+                GeographyPolygons.geometry,
+            )
+            .join(
+                GeographyType,
+                GeographyPolygons.geography_type_id == GeographyType.id,
+            )
+            .filter(
+                GeographyPolygons.geographic_id == area_id,
+                GeographyPolygons.geography_version_id == latest_active_version.id,
+            )
+            .one_or_none()
+        )
+
+    else:
+        latest_geography_versions = dao_get_latest_geography_versions()
+        if latest_geography_versions == []:
+            return None
+
+        latest_version_ids = [v.id for v in latest_geography_versions]
+
+        return (
+            db.session.query(
+                GeographyPolygons.id,
+                GeographyPolygons.geographic_id,
+                GeographyPolygons.name,
+                GeographyPolygons.parent_geography_id,
+                GeographyType.route.label("geography_type_name"),
+                GeographyPolygons.geometry,
+            )
+            .join(
+                GeographyType,
+                GeographyPolygons.geography_type_id == GeographyType.id,
+            )
+            .filter(
+                GeographyPolygons.geographic_id == area_id,
+                GeographyPolygons.geography_version_id.in_(latest_version_ids),
+            )
+            .one_or_none()
+        )
+
+
+def dao_get_areas_by_names(area_names, type_name):
+    """Returns the areas from geography_polygons, with latest version ID"""
+    latest_version_id = dao_get_latest_active_version_for_type_route(type_name).id
+    return (
+        GeographyPolygons.query.filter(GeographyPolygons.name.in_(area_names))
+        .filter_by(geography_version_id=latest_version_id)
+        .all()
+    )
+
+
+def dao_get_area_by_id(area_id):
+    """Returns the area, from geography_polygons, with specified area ID (UUID)"""
+    return (
+        db.session.query(
+            GeographyPolygons.id,
+            GeographyPolygons.geographic_id,
+            GeographyPolygons.name,
+            GeographyPolygons.parent_geography_id,
+            GeographyType.route.label("geography_type_name"),
+            GeographyPolygons.geometry,
+        )
+        .join(
+            GeographyType,
+            GeographyPolygons.geography_type_id == GeographyType.id,
+        )
+        .filter(GeographyPolygons.id == area_id)
+        .one_or_none()
+    )
+
+
+def dao_get_areas_by_ids(area_ids):
+    """Returns list of areas for the specified area IDs"""
+    return (
+        db.session.query(
+            GeographyPolygons.id,
+            GeographyPolygons.geographic_id,
+            GeographyPolygons.name,
+            GeographyPolygons.parent_geography_id,
+            GeographyType.route.label("geography_type_name"),
+            GeographyPolygons.geometry,
+        )
+        .join(
+            GeographyType,
+            GeographyPolygons.geography_type_id == GeographyType.id,
+        )
+        .filter(GeographyPolygons.id.in_(area_ids))
+        .order_by(GeographyPolygons.name)
+        .all()
+    )
+
+
+def dao_get_latest_geography_types_with_count_and_examples():
+    """Returns the types from geography_type table, with latest version IDs,
+    with the result being a list of elements with structure;
+    - type ID
+    - type name
+    - type route
+    - count of areas for the type
+    - first 4 areas for the type
+    - type's name_singular (how singular areas of this type are referred to)
+    """
+    latest_geography_version = dao_get_latest_geography_version_number()
+    query = (
+        db.session.query(
+            GeographyType.id,
+            GeographyType.name.label("geography_type_name"),
+            GeographyType.route,
+            func.count(GeographyPolygons.id).label("area_count"),
+            func.array_agg(
+                aggregate_order_by(
+                    GeographyPolygons.name,
+                    GeographyPolygons.name,
+                )
+            )[
+                1:4
+            ].label("areas"),
+            GeographyType.name_singular,
+        )
+        .join(
+            GeographyVersion,
+            GeographyVersion.geography_type_id == GeographyType.id,
+        )
+        .outerjoin(
+            GeographyPolygons,
+            (GeographyPolygons.geography_type_id == GeographyType.id)
+            & (GeographyPolygons.geography_version_id == GeographyVersion.id),
+        )
+        .filter(GeographyVersion.version == latest_geography_version)
+        .group_by(
+            GeographyType.id,
+            GeographyType.name,
+            GeographyType.route,
+            GeographyType.name_singular,
+        )
+    )
+
+    return query.all()
+
+
+def dao_create_area(geometries):
+    """Combines multiple geometries and returns the combined area as WKT string"""
+    sql = text("""
+        SELECT ST_ASText(
+            ST_UnaryUnion(
+                ST_Collect(geom)
+            )
+        )
+        FROM unnest(:geometries) AS geom
+        """)
+    return db.session.execute(sql, {"geometries": geometries}).scalar()
+
+
+def dao_get_area_centroid(area_id):
+    """Returns the WKT string for centroid calculated for area"""
+    area = dao_get_area_by_id(area_id)
+    if area is None or area.geometry is None:
+        return None
+    geometry = to_shape(area.geometry).wkt
+    query = """
+        SELECT ST_AsText(ST_Centroid(g))
+        FROM ST_GeomFromText(:geometry, 4326) AS g;
+    """
+    return db.session.execute(query, {"geometry": geometry}).scalar()
+
+
+def dao_create_circle_area(centroid, radius):
+    """Returns the area as WKT string for the 'circle' area generated using centroid and radius as buffer"""
+    radius = radius * 1000
+    query = """
+        SELECT
+            ST_AsText(
+                ST_Transform(
+                    ST_Buffer(
+                        ST_Transform(
+                            ST_GeomFromText(:centroid, 4326),
+                            27700
+                        ),
+                        :radius
+                    ),
+                    4326
+                )
+            );
+    """
+    return db.session.execute(query, {"centroid": centroid, "radius": radius}).scalar()
+
+
+def dao_combine_geometries(geometry_1, geometry_2):
+    """Returns the combination of 2 geomtries as WKT string"""
+    query = """
+        SELECT ST_AsText(
+            ST_Union(
+                ST_GeomFromText(:geometry_1, 4326),
+                ST_GeomFromText(:geometry_2, 4326)
+            )
+        );
+    """
+    return db.session.execute(query, {"geometry_1": geometry_1, "geometry_2": geometry_2}).scalar()
+
+
+def dao_check_coordinates_valid(first, second, coordinate_type):
+    if first is None or second is None:
+        return False
+
+    try:
+        first_val = float(first)
+        second_val = float(second)
+    except (TypeError, ValueError):
+        return False
+
+    if coordinate_type == "latitude_longitude":
+        lat = first_val
+        lon = second_val
+        point_wkt = f"POINT({lon} {lat})"
+        srid_in = 4326
+    elif coordinate_type == "easting_northing":
+        easting = first_val
+        northing = second_val
+        point_wkt = f"POINT({easting} {northing})"
+        srid_in = 27700
+
+    # Retrieve the country area IDs as these will be the basis for
+    # checking whether or not coordinates are within UK
+    country_areas = dao_get_areas_for_geography_type("countries")
+    area_ids = [str(area.id) for area in country_areas]
+
+    sql = text("""
+        SELECT EXISTS (
+            SELECT 1
+            FROM geography_polygons gp
+            WHERE gp.id IN :boundary_area_ids
+            AND ST_Contains(
+                gp.geometry,
+                ST_Transform(
+                    ST_GeomFromText(:point_wkt, :srid_in),
+                    4326
+                )
+            )
+        );
+        """)
+
+    result = db.session.execute(
+        sql,
+        {"point_wkt": point_wkt, "srid_in": srid_in, "boundary_area_ids": tuple(area_ids)},
+    ).scalar()
+
+    return bool(result)
+
+
+def dao_get_dominant_parent_geography_id(area_wkt, parent_type_name="local_authorities"):
+    """
+    Given an area geometry in WKT, return the ID of the parent GeographyPolygons
+    of type `parent_type_name` that overlaps it the most (by intersection area),
+    or None.
+
+    `parent_type_name` should match GeographyType.route, e.g. "local_authorities"
+    or "local-authorities" depending on your data.
+    """
+
+    # Look up the GeographyType id for the requested parent type (by route)
+    parent_type = db.session.query(GeographyType.id).filter(GeographyType.route == parent_type_name).first()
+    if not parent_type:
+        return None
+
+    parent_type_id = parent_type.id
+
+    sql = text("""
+        SELECT parent.id
+        FROM geography_polygons AS parent
+        JOIN (
+            SELECT ST_GeomFromText(:area_wkt, 4326) AS geom
+        ) AS child
+          ON ST_Intersects(child.geom, parent.geometry)
+        WHERE parent.geography_type_id = :parent_type_id
+        ORDER BY ST_Area(ST_Intersection(child.geom, parent.geometry)) DESC
+        LIMIT 1
+        """)
+
+    result = db.session.execute(
+        sql,
+        {"area_wkt": area_wkt, "parent_type_id": parent_type_id},
+    ).first()
+
+    return result[0] if result else None

--- a/app/dao/areas_dao.py
+++ b/app/dao/areas_dao.py
@@ -9,7 +9,15 @@ from app.models import GeographyPolygons, GeographyType, GeographyVersion
 
 def dao_get_latest_geography_version_number():
     """Returns latest active version's version number"""
-    return GeographyVersion.query.filter_by(state="active").order_by(GeographyVersion.created_at.desc()).first().version
+    if GeographyVersion.query.filter_by(state="active").order_by(GeographyVersion.created_at.desc()).first():
+        return (
+            GeographyVersion.query.filter_by(state="active")
+            .order_by(GeographyVersion.created_at.desc())
+            .first()
+            .version
+        )
+    else:
+        return None
 
 
 def dao_get_latest_geography_versions():
@@ -37,21 +45,24 @@ def dao_get_latest_active_version_for_type_route(type_name):
 
 
 def dao_get_areas_for_geography_type(type_name):
-    latest_active_version = dao_get_latest_active_version_for_type_route(type_name).id
-    query = (
-        GeographyPolygons.query.with_entities(
-            GeographyPolygons.id,
-            GeographyPolygons.geographic_id,
-            GeographyPolygons.name,
-            GeographyPolygons.parent_geography_id,
+    latest_active_version = dao_get_latest_active_version_for_type_route(type_name)
+    if latest_active_version:
+        latest_active_version_id = latest_active_version.id
+        query = (
+            GeographyPolygons.query.with_entities(
+                GeographyPolygons.id,
+                GeographyPolygons.geographic_id,
+                GeographyPolygons.name,
+                GeographyPolygons.parent_geography_id,
+            )
+            .filter_by(
+                geography_version_id=latest_active_version_id,
+            )
+            .order_by(GeographyPolygons.name)
         )
-        .filter_by(
-            geography_version_id=latest_active_version,
-        )
-        .order_by(GeographyPolygons.name)
-    )
-
-    return query.all()
+        return query.all()
+    else:
+        return []
 
 
 def dao_get_area_by_id(area_id):
@@ -100,10 +111,13 @@ def dao_get_child_areas_for_parent_geography_id(parent_geography_id):
     # as these are the only child areas we are interested in currently
     # Note: REPPIR sites also have parent_geography_id but we don't
     # want them rendered as children for selection
-    latest_la_version_id = dao_get_latest_active_version_for_type_route("local_authorities").id
-    latest_ward_version_id = dao_get_latest_active_version_for_type_route("wards").id
-
-    version_ids = [latest_la_version_id, latest_ward_version_id]
+    latest_la_version_id, latest_ward_version_id, version_ids = None, None, []
+    if latest_la_version := dao_get_latest_active_version_for_type_route("local_authorities"):
+        latest_la_version_id = latest_la_version.id
+        version_ids.append(latest_la_version_id)
+    if latest_ward_version := dao_get_latest_active_version_for_type_route("wards"):
+        latest_ward_version_id = latest_ward_version.id
+        version_ids.append(latest_ward_version_id)
 
     query = (
         GeographyPolygons.query.with_entities(
@@ -157,32 +171,10 @@ def dao_get_latest_area_by_geographic_id(area_id, type_name=None):
 
     if type_name:
         latest_active_version = dao_get_latest_active_version_for_type_route(type_name)
-        return (
-            db.session.query(
-                GeographyPolygons.id,
-                GeographyPolygons.geographic_id,
-                GeographyPolygons.name,
-                GeographyPolygons.parent_geography_id,
-                GeographyType.route.label("geography_type_name"),
-                GeographyPolygons.geometry,
-            )
-            .join(
-                GeographyType,
-                GeographyPolygons.geography_type_id == GeographyType.id,
-            )
-            .filter(
-                GeographyPolygons.geographic_id == area_id,
-                GeographyPolygons.geography_version_id == latest_active_version.id,
-            )
-            .one_or_none()
-        )
-
-    else:
-        latest_geography_versions = dao_get_latest_geography_versions()
-        if latest_geography_versions == []:
+        if not latest_active_version:
             return None
 
-        latest_version_ids = [v.id for v in latest_geography_versions]
+        latest_active_version_id = latest_active_version.id
 
         return (
             db.session.query(
@@ -199,10 +191,36 @@ def dao_get_latest_area_by_geographic_id(area_id, type_name=None):
             )
             .filter(
                 GeographyPolygons.geographic_id == area_id,
-                GeographyPolygons.geography_version_id.in_(latest_version_ids),
+                GeographyPolygons.geography_version_id == latest_active_version_id,
             )
             .one_or_none()
         )
+
+    latest_geography_versions = dao_get_latest_geography_versions()
+    if not latest_geography_versions:
+        return None
+
+    latest_version_ids = [v.id for v in latest_geography_versions]
+
+    return (
+        db.session.query(
+            GeographyPolygons.id,
+            GeographyPolygons.geographic_id,
+            GeographyPolygons.name,
+            GeographyPolygons.parent_geography_id,
+            GeographyType.route.label("geography_type_name"),
+            GeographyPolygons.geometry,
+        )
+        .join(
+            GeographyType,
+            GeographyPolygons.geography_type_id == GeographyType.id,
+        )
+        .filter(
+            GeographyPolygons.geographic_id == area_id,
+            GeographyPolygons.geography_version_id.in_(latest_version_ids),
+        )
+        .one_or_none()
+    )
 
 
 def dao_get_areas_by_names(area_names, type_name):

--- a/app/dao/areas_dao.py
+++ b/app/dao/areas_dao.py
@@ -4,7 +4,6 @@ from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.orm import aliased
 
 from app import db
-from app.areas.utils import COUNTRIES, LOCAL_AUTHORITIES, WARDS
 from app.models import GeographyPolygons, GeographyType, GeographyVersion
 
 
@@ -113,10 +112,10 @@ def dao_get_child_areas_for_parent_geography_id(parent_geography_id):
     # Note: REPPIR sites also have parent_geography_id but we don't
     # want them rendered as children for selection
     latest_la_version_id, latest_ward_version_id, version_ids = None, None, []
-    if latest_la_version := dao_get_latest_active_version_for_type_route(LOCAL_AUTHORITIES):
+    if latest_la_version := dao_get_latest_active_version_for_type_route("local_authorities"):
         latest_la_version_id = latest_la_version.id
         version_ids.append(latest_la_version_id)
-    if latest_ward_version := dao_get_latest_active_version_for_type_route(WARDS):
+    if latest_ward_version := dao_get_latest_active_version_for_type_route("wards"):
         latest_ward_version_id = latest_ward_version.id
         version_ids.append(latest_ward_version_id)
 
@@ -137,8 +136,8 @@ def dao_get_child_areas_for_parent_geography_id(parent_geography_id):
 
 def dao_get_grandparent_areas():
     """Returns list of areas that have child areas that are parent areas"""
-    latest_la_version_id = dao_get_latest_active_version_for_type_route(LOCAL_AUTHORITIES).id
-    latest_ward_version_id = dao_get_latest_active_version_for_type_route(WARDS).id
+    latest_la_version_id = dao_get_latest_active_version_for_type_route("local_authorities").id
+    latest_ward_version_id = dao_get_latest_active_version_for_type_route("wards").id
 
     version_ids = [latest_la_version_id, latest_ward_version_id]
 
@@ -365,7 +364,7 @@ def dao_check_coordinates_valid(first, second, coordinate_type):
 
     # Retrieve the country area IDs as these will be the basis for
     # checking whether or not coordinates are within UK
-    country_areas = dao_get_areas_for_geography_type(COUNTRIES)
+    country_areas = dao_get_areas_for_geography_type("countries")
     area_ids = [str(area.id) for area in country_areas]
 
     sql = text("""
@@ -391,14 +390,14 @@ def dao_check_coordinates_valid(first, second, coordinate_type):
     return bool(result)
 
 
-def dao_get_dominant_parent_geography_id(area_wkt, parent_type_name=LOCAL_AUTHORITIES):
+def dao_get_dominant_parent_geography_id(area_wkt, parent_type_name="local_authorities"):
     """
     Given an area geometry in WKT, return the ID of the parent GeographyPolygons
     of type `parent_type_name` that overlaps it the most (by intersection area),
     or None.
 
     `parent_type_name` should match GeographyType.route, e.g. "local_authorities"
-    or "wards" depending on your data.
+    or "local-authorities" depending on your data.
     """
 
     # Look up the GeographyType id for the requested parent type (by route)

--- a/app/dao/areas_dao.py
+++ b/app/dao/areas_dao.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.orm import aliased
 
 from app import db
+from app.areas.utils import COUNTRIES, LOCAL_AUTHORITIES, WARDS
 from app.models import GeographyPolygons, GeographyType, GeographyVersion
 
 
@@ -112,10 +113,10 @@ def dao_get_child_areas_for_parent_geography_id(parent_geography_id):
     # Note: REPPIR sites also have parent_geography_id but we don't
     # want them rendered as children for selection
     latest_la_version_id, latest_ward_version_id, version_ids = None, None, []
-    if latest_la_version := dao_get_latest_active_version_for_type_route("local_authorities"):
+    if latest_la_version := dao_get_latest_active_version_for_type_route(LOCAL_AUTHORITIES):
         latest_la_version_id = latest_la_version.id
         version_ids.append(latest_la_version_id)
-    if latest_ward_version := dao_get_latest_active_version_for_type_route("wards"):
+    if latest_ward_version := dao_get_latest_active_version_for_type_route(WARDS):
         latest_ward_version_id = latest_ward_version.id
         version_ids.append(latest_ward_version_id)
 
@@ -136,8 +137,8 @@ def dao_get_child_areas_for_parent_geography_id(parent_geography_id):
 
 def dao_get_grandparent_areas():
     """Returns list of areas that have child areas that are parent areas"""
-    latest_la_version_id = dao_get_latest_active_version_for_type_route("local_authorities").id
-    latest_ward_version_id = dao_get_latest_active_version_for_type_route("wards").id
+    latest_la_version_id = dao_get_latest_active_version_for_type_route(LOCAL_AUTHORITIES).id
+    latest_ward_version_id = dao_get_latest_active_version_for_type_route(WARDS).id
 
     version_ids = [latest_la_version_id, latest_ward_version_id]
 
@@ -364,7 +365,7 @@ def dao_check_coordinates_valid(first, second, coordinate_type):
 
     # Retrieve the country area IDs as these will be the basis for
     # checking whether or not coordinates are within UK
-    country_areas = dao_get_areas_for_geography_type("countries")
+    country_areas = dao_get_areas_for_geography_type(COUNTRIES)
     area_ids = [str(area.id) for area in country_areas]
 
     sql = text("""
@@ -390,14 +391,14 @@ def dao_check_coordinates_valid(first, second, coordinate_type):
     return bool(result)
 
 
-def dao_get_dominant_parent_geography_id(area_wkt, parent_type_name="local_authorities"):
+def dao_get_dominant_parent_geography_id(area_wkt, parent_type_name=LOCAL_AUTHORITIES):
     """
     Given an area geometry in WKT, return the ID of the parent GeographyPolygons
     of type `parent_type_name` that overlaps it the most (by intersection area),
     or None.
 
     `parent_type_name` should match GeographyType.route, e.g. "local_authorities"
-    or "local-authorities" depending on your data.
+    or "wards" depending on your data.
     """
 
     # Look up the GeographyType id for the requested parent type (by route)

--- a/app/dao/populations_dao.py
+++ b/app/dao/populations_dao.py
@@ -3,13 +3,20 @@ from app import db
 
 def dao_estimate_population_for_area(polygon):
     # Estimates population by calculating the intersection of the area
-    # with areas with known population counts
+    # with areas with known population counts that are covered by the area
     query = """WITH proposed_polygon AS (
                 SELECT ST_GeomFromText(:polygon, 4326) AS geom
             )
             SELECT
                 SUM(
-                    t.density * (ST_Area(ST_Intersection(t.geometry, proposed_polygon.geom))/ ST_Area(t.geometry))
+                    CASE
+                        WHEN ST_Covers(proposed_polygon.geom, t.geometry)
+                            THEN t.density
+                        ELSE t.density *
+                        (
+                            ST_Area(ST_Intersection(t.geometry, proposed_polygon.geom))/ ST_Area(t.geometry)
+                        )
+                    END
                 ) AS estimated_population
             FROM populations t, proposed_polygon
             WHERE ST_Intersects(t.geometry, proposed_polygon.geom)

--- a/app/dao/populations_dao.py
+++ b/app/dao/populations_dao.py
@@ -16,3 +16,21 @@ def dao_estimate_population_for_area(polygon):
         """
     result = db.session.execute(query, {"polygon": polygon}).fetchone()
     return result[0] or 0
+
+
+def dao_estimate_population_and_area_for_area(polygon):
+    query = """WITH proposed_polygon AS (
+                SELECT ST_GeomFromText(:polygon, 4326) AS geom
+            )
+            SELECT
+                SUM(
+                    t.density * (ST_Area(ST_Intersection(t.geometry, proposed_polygon.geom))/ ST_Area(t.geometry))
+                ) AS estimated_population,
+                MAX(
+                    ST_Area(proposed_polygon.geom::geography)
+                ) as estimated_area
+            FROM populations t, proposed_polygon
+            WHERE ST_Intersects(t.geometry, proposed_polygon.geom)
+        """
+    result = db.session.execute(query, {"polygon": polygon}).fetchone()
+    return {"estimated_population": result[0] or 0, "estimated_area": result[1] or 0}

--- a/app/models.py
+++ b/app/models.py
@@ -1511,3 +1511,76 @@ class RouteAdvisor(db.Model):
             "target": self.target,
             "updated_at": self.updated_at,
         }
+
+
+class GeographyType(db.Model):
+    __tablename__ = "geography_type"
+
+    id = db.Column(db.String, primary_key=True)
+    name = db.Column(db.String, nullable=False, unique=True)
+    route = db.Column(db.String, nullable=True, unique=True)
+    name_singular = db.Column(db.String, nullable=True, unique=True)
+
+    versions = db.relationship("GeographyVersion", back_populates="geography_type")
+    polygons = db.relationship("GeographyPolygon", back_populates="geography_type")
+
+    def serialize(self):
+        return {"id": self.id, "name": self.name, "route": self.route, "name_singular": self.name_singular}
+
+
+class GeographyVersion(db.Model):
+    __tablename__ = "geography_version"
+
+    id = db.Column(db.String, primary_key=True)
+    geography_type_id = db.Column(db.String, db.ForeignKey("geography_type.id"), nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False)
+    version = db.Column(db.String, nullable=False)
+    source_url = db.Column(db.String, nullable=False)
+    state = db.Column(db.String, nullable=False)
+
+    geography_type = db.relationship("GeographyType", back_populates="versions")
+    polygons = db.relationship("GeographyPolygon", back_populates="geography_version")
+
+    def serialize(self):
+        return {
+            "id": self.id,
+            "geography_type_id": self.geography_type_id,
+            "created_at": self.created_at.strftime(DATETIME_FORMAT),
+            "version": self.version,
+            "source_url": self.source_url,
+            "state": self.state,
+        }
+
+
+class GeographyPolygon(db.Model):
+    __tablename__ = "geography_polygons"
+
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    geographic_id = db.Column(db.String)
+    name = db.Column(db.String, nullable=False)
+    geometry = db.Column(Geometry("GEOMETRY", srid=4326), nullable=False)
+
+    parent_geography_id = db.Column(db.String, nullable=True)
+
+    geography_version_id = db.Column(
+        db.String,
+        db.ForeignKey("geography_version.id"),
+        nullable=False,
+    )
+    geography_type_id = db.Column(
+        db.String,
+        db.ForeignKey("geography_type.id"),
+        nullable=False,
+    )
+
+    geography_version = db.relationship("GeographyVersion", back_populates="polygons")
+    geography_type = db.relationship("GeographyType", back_populates="polygons")
+
+    def serialize(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "geography_type_id": self.geography_type_id,
+            "geography_version_id": self.geography_version_id,
+            "parent_geography_id": self.parent_geography_id,
+        }

--- a/app/models.py
+++ b/app/models.py
@@ -1533,7 +1533,7 @@ class GeographyType(db.Model):
     name_singular = db.Column(db.String, nullable=True, unique=True)
 
     versions = db.relationship("GeographyVersion", back_populates="geography_type")
-    polygons = db.relationship("GeographyPolygon", back_populates="geography_type")
+    polygons = db.relationship("GeographyPolygons", back_populates="geography_type")
 
     def serialize(self):
         return {"id": self.id, "name": self.name, "route": self.route, "name_singular": self.name_singular}
@@ -1550,7 +1550,7 @@ class GeographyVersion(db.Model):
     state = db.Column(db.String, nullable=False)
 
     geography_type = db.relationship("GeographyType", back_populates="versions")
-    polygons = db.relationship("GeographyPolygon", back_populates="geography_version")
+    polygons = db.relationship("GeographyPolygons", back_populates="geography_version")
 
     def serialize(self):
         return {
@@ -1563,7 +1563,7 @@ class GeographyVersion(db.Model):
         }
 
 
-class GeographyPolygon(db.Model):
+class GeographyPolygons(db.Model):
     __tablename__ = "geography_polygons"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/app/models.py
+++ b/app/models.py
@@ -1530,6 +1530,7 @@ class GeographyType(db.Model):
     id = db.Column(db.String, primary_key=True)
     name = db.Column(db.String, nullable=False, unique=True)
     route = db.Column(db.String, nullable=True, unique=True)
+    # How a single area from this library is referred to in Admin application
     name_singular = db.Column(db.String, nullable=True, unique=True)
 
     versions = db.relationship("GeographyVersion", back_populates="geography_type")
@@ -1567,6 +1568,7 @@ class GeographyPolygons(db.Model):
     __tablename__ = "geography_polygons"
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    #  Office for National Statistics (ONS) and Government Statistical Service (GSS) code for the area
     geographic_id = db.Column(db.String)
     name = db.Column(db.String, nullable=False)
     geometry = db.Column(Geometry("GEOMETRY", srid=4326), nullable=False)

--- a/migrations/versions/0430_adjust_area_tables.py
+++ b/migrations/versions/0430_adjust_area_tables.py
@@ -1,0 +1,144 @@
+"""
+
+Revision ID: 0430_adjust_area_tables
+Revises: 0429_unescape_message_content
+Create Date: 2026-08-05 14:22:30
+
+"""
+
+import uuid
+
+from geoalchemy2 import Geometry
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0430_adjust_area_tables"
+down_revision = "0429_unescape_message_content"
+
+
+def upgrade():
+    # Clearing all existing data to add the new column
+    op.execute("DELETE FROM geography_polygons")
+    op.execute("DELETE FROM geography_version")
+    op.execute("DELETE FROM geography_type")
+
+    op.add_column("geography_type", sa.Column("name_singular", sa.Text(), nullable=True))
+
+    op.drop_table("geography_polygons")
+
+    op.create_table(
+        "geography_polygons",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False, unique=True, default=uuid.uuid4),
+        sa.Column("geographic_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),
+        sa.Column("parent_geography_id", sa.String(), nullable=True),
+        sa.Column("geography_version_id", sa.String(), nullable=False),
+        # Stored for optimisation purposes - not strictly necessary as we can retrieve
+        # geography_type_id from geography_version relation in first instance
+        sa.Column("geography_type_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["geography_version_id"],
+            ["geography_version.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["geography_type_id"],
+            ["geography_type.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_geography_polygons_id",
+        "geography_polygons",
+        ["id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geographic_id",
+        "geography_polygons",
+        ["geographic_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_name",
+        "geography_polygons",
+        ["name"],
+    )
+    op.create_index(
+        "ix_geography_polygons_parent_geography_id",
+        "geography_polygons",
+        ["parent_geography_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_version_id",
+        "geography_polygons",
+        ["geography_version_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_type_id",
+        "geography_polygons",
+        ["geography_type_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geometry",
+        "geography_polygons",
+        ["geometry"],
+        postgresql_using="gist",
+    )
+
+
+def downgrade():
+    # Dropping everything related to geography_polygons table before we re-add with adjustments
+    op.drop_column("geography_type", "name_singular")
+    op.drop_table("geography_polygons")
+
+    op.create_table(
+        "geography_polygons",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),
+        sa.Column("parent_geography_id", sa.String(), nullable=True),
+        sa.Column("geography_version_id", sa.String(), nullable=False),
+        # Stored for optimisation purposes - not strictly necessary as we can retrieve
+        # geography_type_id from geography_version relation in first instance
+        sa.Column("geography_type_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["geography_version_id"],
+            ["geography_version.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["geography_type_id"],
+            ["geography_type.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_geography_polygons_id",
+        "geography_polygons",
+        ["id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_name",
+        "geography_polygons",
+        ["name"],
+    )
+    op.create_index(
+        "ix_geography_polygons_parent_geography_id",
+        "geography_polygons",
+        ["parent_geography_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_version_id",
+        "geography_polygons",
+        ["geography_version_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geography_type_id",
+        "geography_polygons",
+        ["geography_type_id"],
+    )
+    op.create_index(
+        "ix_geography_polygons_geometry",
+        "geography_polygons",
+        ["geometry"],
+        postgresql_using="gist",
+    )

--- a/migrations/versions/0431_adjust_area_tables.py
+++ b/migrations/versions/0431_adjust_area_tables.py
@@ -1,7 +1,7 @@
 """
 
-Revision ID: 0430_adjust_area_tables
-Revises: 0429_unescape_message_content
+Revision ID: 0431_adjust_area_tables.py
+Revises: 0430_add_bpm_err_retry_exhausted
 Create Date: 2026-08-05 14:22:30
 
 """
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision = "0430_adjust_area_tables"
-down_revision = "0429_unescape_message_content"
+revision = "0431_adjust_area_tables.py"
+down_revision = "0430_add_bpm_err_retry_exhausted"
 
 
 def upgrade():

--- a/migrations/versions/0431_adjust_area_tables.py
+++ b/migrations/versions/0431_adjust_area_tables.py
@@ -8,9 +8,9 @@ Create Date: 2026-08-05 14:22:30
 
 import uuid
 
-from geoalchemy2 import Geometry
 import sqlalchemy as sa
 from alembic import op
+from geoalchemy2 import Geometry
 from sqlalchemy.dialects import postgresql
 
 revision = "0431_adjust_area_tables.py"
@@ -30,6 +30,7 @@ def upgrade():
     op.create_table(
         "geography_polygons",
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False, unique=True, default=uuid.uuid4),
+        #  Office for National Statistics (ONS) and Government Statistical Service (GSS) code for the area e.g. England's is E92000001
         sa.Column("geographic_id", sa.String(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("geometry", Geometry("GEOMETRY", srid=4326), nullable=False),

--- a/migrations/versions/0431_adjust_area_tables.py
+++ b/migrations/versions/0431_adjust_area_tables.py
@@ -90,7 +90,7 @@ def upgrade():
 
 def downgrade():
     # Dropping everything related to geography_polygons table before we re-add with adjustments
-    op.drop_column("geography_type", "name_singular") 
+    op.drop_column("geography_type", "name_singular")
     op.drop_table("geography_polygons")
 
     op.create_table(

--- a/migrations/versions/0431_adjust_area_tables.py
+++ b/migrations/versions/0431_adjust_area_tables.py
@@ -23,6 +23,7 @@ def upgrade():
     op.execute("DELETE FROM geography_version")
     op.execute("DELETE FROM geography_type")
 
+    # How a single area from this library is referred to in Admin application
     op.add_column("geography_type", sa.Column("name_singular", sa.Text(), nullable=True))
 
     op.drop_table("geography_polygons")
@@ -89,7 +90,7 @@ def upgrade():
 
 def downgrade():
     # Dropping everything related to geography_polygons table before we re-add with adjustments
-    op.drop_column("geography_type", "name_singular")
+    op.drop_column("geography_type", "name_singular") 
     op.drop_table("geography_polygons")
 
     op.create_table(

--- a/scripts/adding_area_data/add_areas_data.py
+++ b/scripts/adding_area_data/add_areas_data.py
@@ -1,37 +1,32 @@
 import os
 import uuid
 from datetime import datetime, timezone
-import pandas as pd
 
 from utils import (
-    copy_dataframe_to_table,
     create_db_connection,
     get_source_data,
     insert_data_into_table,
+    split_into_chunks_and_insert_into_db,
 )
 
 VERSION = "1.0.0"
 AREAS_SOURCE_BUCKET = os.environ.get("AREAS_SOURCE_BUCKET_NAME")
 
-AREAS = [
-    "postcodes",
-    "countries",
-    "counties_and_unitary_authorities",
-    "reppir_sites",
-    "test",
-    "local_authority_districts",
-    "flood_warning_areas",
-    "wards",
-]
-
-GEOGRAPHY_POLYGON_COLUMNS = [
-    "id",
-    "name",
-    "geometry",
-    "parent_geography_id",
-    "geography_version_id",
-    "geography_type_id",
-]
+AREAS = {
+    "postcodes": {"display_name": "Postcode areas", "name_singular": "postcode area"},
+    "countries": {"display_name": "Countries", "name_singular": "country"},
+    "reppir_sites": {"display_name": "REPPIR DEPZ sites", "name_singular": "REPPIR DEPZ site"},
+    "test": {"display_name": "Test areas", "name_singular": "test area"},
+    "flood_warning_areas": {
+        "display_name": "Flood Warning Target Areas (TA code)",
+        "name_singular": "Flood Warning Target Area",
+    },
+    "wards": {"display_name": "Wards", "name_singular": "ward"},
+    "local_authorities": {
+        "display_name": "Local authorities",
+        "name_singular": "local authority",
+    },
+}
 
 
 def insert_geography_version(conn, area, geography_type_id):
@@ -58,32 +53,30 @@ def insert_geography_version(conn, area, geography_type_id):
 def insert_geography_type(conn, area):
     # Inserts geography_type row for a given area
     geography_type_id = str(uuid.uuid4())
+    geography_name = AREAS[area]["display_name"]
+    name_singular = AREAS[area]["name_singular"]
     insert_data_into_table(
         conn,
         "geography_type",
-        ("id", "name", "route"),
-        [(geography_type_id, area, area)],
+        ("id", "name", "route", "name_singular"),
+        [(geography_type_id, geography_name, area, name_singular)],
     )
     return geography_type_id
 
 
 def insert_geography_polygons(conn, area, geography_version_id, geography_type_id):
     # Insert geography_polygons rows for a given area
-    data = get_source_data(f"{VERSION}/{area}.csv")
-    # Splits CSV into chunks for chunk/batch processing
-    csv_data_chunks = pd.read_csv(data, index_col=False, chunksize=100000)
-    current_chunk = 1
-    for chunk in csv_data_chunks:
-        # Adds columns for geography_version_id & geography_type_id, values are generated within this script
-        chunk["geography_version_id"] = geography_version_id
-        chunk["geography_type_id"] = geography_type_id
-
-        try:
-            copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, chunk)
-            print(f"{area} geography_polygons data has been added to the table - chunk #{current_chunk}")
-            current_chunk += 1
-        except Exception as exc:
-            print(f"Could not add {area} data to geography_polygons table: {exc}")
+    if area == "local_authorities":
+        # If the area is local_authorities, these are made up of counties_and_unitary_authorities
+        # and local_authority_districts
+        for sub_area in ["counties_and_unitary_authorities", "local_authority_districts"]:
+            data = get_source_data(f"{VERSION}/{sub_area}.csv")
+            # Splits CSV into chunks for chunk/batch processing
+            split_into_chunks_and_insert_into_db(conn, area, geography_version_id, geography_type_id, data)
+    else:
+        data = get_source_data(f"{VERSION}/{area}.csv")
+        # Splits CSV into chunks for chunk/batch processing
+        split_into_chunks_and_insert_into_db(conn, area, geography_version_id, geography_type_id, data)
 
 
 def main():

--- a/scripts/adding_area_data/utils.py
+++ b/scripts/adding_area_data/utils.py
@@ -1,10 +1,23 @@
-from io import StringIO
 import os
+import uuid
+from io import StringIO
+
 import boto3
+import pandas as pd
 import psycopg2
 
 s3 = boto3.client("s3")
 AREAS_SOURCE_BUCKET = os.environ.get("AREAS_SOURCE_BUCKET_NAME")
+
+GEOGRAPHY_POLYGON_COLUMNS = [
+    "id",
+    "geographic_id",
+    "name",
+    "geometry",
+    "parent_geography_id",
+    "geography_version_id",
+    "geography_type_id",
+]
 
 
 def get_source_data(filename):
@@ -64,3 +77,20 @@ def insert_data_into_table(conn, table_name, columns, values):
         print(f"{table_name} data has been added to the table")
     except Exception as e:
         print(f"Could not add data to {table_name} table as {e}")
+
+
+def split_into_chunks_and_insert_into_db(conn, area, geography_version_id, geography_type_id, data):
+    csv_data_chunks = pd.read_csv(data, index_col=False, chunksize=100000)
+    current_chunk = 1
+    for chunk in csv_data_chunks:
+        # Adds columns for geography_version_id & geography_type_id, values are generated within this script
+        chunk["id"] = [uuid.uuid4() for _ in range(len(chunk))]
+        chunk["geography_version_id"] = geography_version_id
+        chunk["geography_type_id"] = geography_type_id
+
+        try:
+            copy_dataframe_to_table(conn, "geography_polygons", GEOGRAPHY_POLYGON_COLUMNS, chunk)
+            print(f"{area} geography_polygons data has been added to the table - chunk #{current_chunk}")
+            current_chunk += 1
+        except Exception as exc:
+            print(f"Could not add {area} data to geography_polygons table: {exc}")

--- a/tests/app/areas/test_rest.py
+++ b/tests/app/areas/test_rest.py
@@ -1,0 +1,834 @@
+import uuid
+
+import pytest
+
+from tests.app.db import (
+    create_area,
+    create_area_with_version_and_type,
+    create_broadcast_message,
+    create_geography_type,
+    create_geography_version,
+    create_template,
+)
+
+
+def test_assert_get_area_returns_area_for_id(admin_request, sample_broadcast_service):
+    area1_id = uuid.uuid4()
+    area1, geography_type, geography_type = create_area_with_version_and_type(id=area1_id)
+    response = admin_request.get(
+        "areas.get_area", area_id=area1_id, service_id=sample_broadcast_service.id, _expected_status=200
+    )
+
+    assert response["data"] == {
+        "geographic_id": area1.geographic_id,
+        "geography_type": "Test route",
+        "id": str(area1_id),
+        "name": area1.name,
+        "parent": area1.parent_geography_id,
+    }
+
+
+def test_assert_get_area_returns_400_when_area_not_found(notify_db_session, admin_request, sample_broadcast_service):
+    response = admin_request.get(
+        "areas.get_area", area_id=uuid.uuid4(), service_id=sample_broadcast_service.id, _expected_status=400
+    )
+    assert response == {"message": "No area with this ID"}
+
+
+def test_assert_get_area_by_geographic_id_returns_area_with_geographic_id(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    area1, geography_version, geography_type = create_area_with_version_and_type()
+    response = admin_request.get(
+        "areas.get_area_by_geographic_id_endpoint",
+        geographic_id=str(area1.geographic_id),
+        service_id=sample_broadcast_service.id,
+        _expected_status=200,
+    )
+
+    assert response["data"] == {
+        "geographic_id": area1.geographic_id,
+        "geography_type": "Test route",
+        "id": str(area1.id),
+        "name": area1.name,
+        "parent": area1.parent_geography_id,
+    }
+
+
+def test_assert_get_area_by_geographic_id_returns_None_if_incorrect_area_id(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    response = admin_request.get(
+        "areas.get_area_by_geographic_id_endpoint",
+        geographic_id="fake-geographic-id",
+        service_id=sample_broadcast_service.id,
+        _expected_status=400,
+    )
+
+    assert response == {"message": "No area retrieved for this geographic ID."}
+
+
+def test_get_areas_returns_areas(notify_db_session, admin_request, sample_broadcast_service):
+    area1, geography_version, geography_type = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, geography_version, geography_type = create_area_with_version_and_type()
+
+    response = admin_request.post(
+        "areas.get_areas",
+        service_id=sample_broadcast_service.id,
+        _data={
+            "area_ids": [str(area1.id), str(area2.id)],
+            "area_names": [area1.name, area2.name],
+        },
+        _expected_status=200,
+    )
+
+    assert len(response["data"]) == 2
+    assert [area.get("id") for area in response["data"]] == [str(area1.id), str(area2.id)]
+
+
+def test_assert_area_is_grandparent_returns_bool_value(notify_db_session, admin_request, sample_broadcast_service):
+    geography_type = create_geography_type(route="local_authorities")
+    geography_version = create_geography_version(geography_type_id=geography_type.id)
+
+    ward_geography_type = create_geography_type(name="Wards", route="wards")
+    create_geography_version(geography_type_id=ward_geography_type.id)
+
+    grandparent = create_area(
+        geography_type_id=geography_type.id, geography_version_id=geography_version.id, geographic_id="grandparent"
+    )
+    parent = create_area(
+        parent_geography_id=grandparent.geographic_id,
+        geography_type_id=geography_type.id,
+        geography_version_id=geography_version.id,
+        geographic_id="parent",
+    )
+    child = create_area(
+        parent_geography_id=parent.geographic_id,
+        geography_type_id=geography_type.id,
+        geography_version_id=geography_version.id,
+        geographic_id="child",
+    )
+
+    resp_true = admin_request.get(
+        "areas.is_grandparent",
+        area_id=grandparent.id,
+        _expected_status=200,
+    )
+    assert resp_true["data"] is True
+    resp_false = admin_request.get(
+        "areas.is_grandparent",
+        area_id=child.id,
+        _expected_status=200,
+    )
+    assert resp_false["data"] is False
+
+
+def test_asserts_get_geography_types_and_examples_returns_valid_response_for_type(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    area, geography_version, geography_type = create_area_with_version_and_type(geography_type_name="Local authorities")
+
+    response = admin_request.get(
+        "areas.get_geography_types_and_examples",
+        service_id=sample_broadcast_service.id,
+        _expected_status=200,
+    )
+
+    assert response["data"] == [
+        {
+            "examples": area.name,  # only the 1 area so 1 name
+            "id": geography_type.id,
+            "name": geography_type.name,
+            "name_singular": geography_type.name_singular,
+            "route": geography_type.route,
+        }
+    ]
+
+
+def test_get_areas_for_type_returns_all_areas_for_valid_type(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    geography_type = create_geography_type(name="Local authorities", route="local_authorities")
+    geography_version = create_geography_version(geography_type_id=geography_type.id)
+
+    area1 = create_area(geography_type_id=geography_type.id, geography_version_id=geography_version.id)
+    area2 = create_area(geography_type_id=geography_type.id, geography_version_id=geography_version.id)
+
+    resp = admin_request.get(
+        "areas.get_areas_for_type",
+        type_name="local_authorities",
+        service_id=sample_broadcast_service.id,
+        _expected_status=200,
+    )
+
+    assert [a["geographic_id"] for a in resp["data"]] == [area1.geographic_id, area2.geographic_id]
+
+
+def test_get_areas_for_type_returns_empty_list_for_invalid_type(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    resp = admin_request.get(
+        "areas.get_areas_for_type",
+        type_name="not-a-real-type",
+        service_id=sample_broadcast_service.id,
+        _expected_status=200,
+    )
+
+    assert resp["data"] == []
+
+
+def test_get_child_areas_for_parent_returns_all_child_areas_for_valid_parent(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    geography_type = create_geography_type(route="local_authorities")
+    geography_version = create_geography_version(geography_type_id=geography_type.id)
+
+    parent = create_area(geography_type_id=geography_type.id, geography_version_id=geography_version.id)
+    child1 = create_area(
+        parent_geography_id=parent.geographic_id,
+        geography_type_id=geography_type.id,
+        geography_version_id=geography_version.id,
+    )
+    child2 = create_area(
+        parent_geography_id=parent.geographic_id,
+        geography_type_id=geography_type.id,
+        geography_version_id=geography_version.id,
+    )
+
+    resp = admin_request.get(
+        "areas.get_child_areas_for_parent",
+        parent_geography_id=str(parent.geographic_id),
+        service_id=sample_broadcast_service.id,
+        _expected_status=200,
+    )
+
+    assert {a["geographic_id"] for a in resp["data"]} == {child1.geographic_id, child2.geographic_id}
+
+
+def test_get_child_areas_for_parent_returns_empty_list_for_area_with_no_children(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    geography_type = create_geography_type(route="local_authorities")
+    geography_version = create_geography_version(geography_type_id=geography_type.id)
+
+    parent = create_area(geography_type_id=geography_type.id, geography_version_id=geography_version.id)
+
+    resp = admin_request.get(
+        "areas.get_child_areas_for_parent",
+        parent_geography_id=str(parent.geographic_id),
+        service_id=sample_broadcast_service.id,
+        _expected_status=200,
+    )
+
+    assert resp["data"] == []
+
+
+def test_get_postcode_centroid_returns_expected_centroid_for_area(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    area, _, _ = create_area_with_version_and_type(geographic_id="Test Postcode", geography_type_route="postcodes")
+
+    resp = admin_request.post(
+        "areas.get_postcode_centroid",
+        _data={"postcode": area.geographic_id},
+        _expected_status=200,
+    )
+
+    assert resp["data"] == "POINT(-1.2 53.925000000000004)"  # Centroid WKT for default geometry
+
+
+def test_get_postcode_centroid_returns_error_for_invalid_postcode(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    area, _, _ = create_area_with_version_and_type(geography_type_route="postcodes")
+
+    resp = admin_request.post(
+        "areas.get_postcode_centroid",
+        _data={"postcode": "NOT A REAL POSTCODE"},
+        _expected_status=400,
+    )
+    assert resp == {"message": "Enter a postcode within the UK"}
+
+
+@pytest.mark.parametrize(
+    "data, expected_wkt",
+    [
+        (
+            {"first_coordinate": 51, "second_coordinate": -0.3, "coordinate_type": "latitude_longitude"},
+            "POINT (-0.3 51)",
+        ),
+        (
+            {"first_coordinate": 528000, "second_coordinate": 178000, "coordinate_type": "easting_northing"},
+            "POINT (-0.1578785176339254 51.48647326506538)",
+        ),
+    ],
+)
+def test_get_coordinate_centroid_returns_expected_centroid_for_area(
+    notify_db_session, admin_request, sample_broadcast_service, data, expected_wkt
+):
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21",
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE",
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840",
+    )
+    area, geography_version, geography_type = create_area_with_version_and_type(
+        geography_type_route="countries", geometry="".join(country_geometry)
+    )
+
+    resp = admin_request.post(
+        "areas.get_coordinates_centroid",
+        _data=data,
+        _expected_status=200,
+    )
+
+    assert resp["data"] == expected_wkt  # Centroid WKT
+
+
+def test_get_coordinates_centroid_returns_error_for_invalid_geometry(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21",
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE",
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840",
+    )
+    area, geography_version, geography_type = create_area_with_version_and_type(
+        geography_type_route="countries", geometry="".join(country_geometry)
+    )
+
+    resp = admin_request.post(
+        "areas.get_coordinates_centroid",
+        area_id=area.id,
+        _data={"first_coordinate": 0, "second_coordinate": 0, "coordinate_type": "latitude_longitude"},
+        _expected_status=400,
+    )
+
+    assert resp == {"message": "Enter coordinates within the UK"}
+
+
+def test_get_areas_by_names_returns_expected_areas(notify_db_session, admin_request, sample_broadcast_service):
+    geography_type = create_geography_type(name="Local authorities", route="local_authorities")
+    geography_version = create_geography_version(geography_type_id=geography_type.id)
+
+    area1 = create_area(
+        geography_type_id=geography_type.id, geography_version_id=geography_version.id, name="Local authority 1"
+    )
+    area2 = create_area(
+        geography_type_id=geography_type.id, geography_version_id=geography_version.id, name="Local authority 2"
+    )
+
+    resp = admin_request.post(
+        "areas.get_areas_by_names",
+        type_name="local_authorities",
+        _data={"area_names": ["Local authority 1", "Local authority 2"]},
+        _expected_status=200,
+    )
+    assert resp["data"] == [str(area1.id), str(area2.id)]
+
+
+@pytest.mark.parametrize(
+    "data, expected_error_message",
+    [
+        # missing_data
+        (
+            {"area_names": []},
+            "Enter at least 1 local authority",
+        ),
+        # duplicates
+        (
+            {"area_names": ["Local authority 1", "Local authority 1"]},
+            "All local authorities must be unique",
+        ),
+        # invalid
+        (
+            {"area_names": ["Fake area"]},
+            "Local authority 'Fake area' not found",
+        ),
+        # exceeds_limit
+        (
+            {"area_names": [f"Local authority {i}" for i in range(1, 27)]},
+            "Maximum of 25 local authorities allowed as a list in one emergency alert",
+        ),
+    ],
+)
+def test_get_local_authorities_areas_by_names_returns_expected_error_for_invalid_input(
+    notify_db_session, admin_request, sample_broadcast_service, data, expected_error_message
+):
+    geography_type = create_geography_type(name="Local authorities", route="local_authorities")
+    create_geography_version(geography_type_id=geography_type.id)
+    resp = admin_request.post(
+        "areas.get_areas_by_names",
+        type_name="local_authorities",
+        _data=data,
+        _expected_status=400,
+    )
+
+    assert resp == {"message": expected_error_message}
+
+
+@pytest.mark.parametrize(
+    "data, expected_error_message",
+    [
+        # missing_data
+        (
+            {"area_names": []},
+            "Enter at least 1 Flood Warning TA code",
+        ),
+        # duplicates
+        (
+            {"area_names": ["Flood Warning TA code 1", "Flood Warning TA code 1"]},
+            "All Flood Warning TA codes must be unique",
+        ),
+        # invalid
+        (
+            {"area_names": ["Fake area"]},
+            "Flood Warning TA code not found",
+        ),
+        # exceeds_limit
+        (
+            {"area_names": [f"Flood Warning TA code {i}" for i in range(1, 27)]},
+            "Maximum of 25 TA codes in an emergency alert",
+        ),
+    ],
+)
+def test_get_flood_warning_areas_by_names_returns_expected_error_for_invalid_input(
+    notify_db_session, admin_request, sample_broadcast_service, data, expected_error_message
+):
+    geography_type = create_geography_type(name="Flood Warning areas", route="flood_warning_areas")
+    create_geography_version(geography_type_id=geography_type.id)
+    resp = admin_request.post(
+        "areas.get_areas_by_names",
+        type_name="flood_warning_areas",
+        _data=data,
+        _expected_status=400,
+    )
+
+    assert resp == {"message": expected_error_message}
+
+
+def test_create_postcode_area_creates_valid_area_for_input(notify_db_session, admin_request, sample_broadcast_service):
+    area, _, _ = create_area_with_version_and_type(
+        geographic_id="Test Postcode",
+        geography_type_route="postcodes",
+    )
+
+    resp = admin_request.post(
+        "areas.create_postcode_area",
+        _data={"postcode": "Test Postcode", "radius": 5},
+        _expected_status=200,
+    )
+    assert "circle" in resp
+    assert resp["id"] == "postcodes_-1.2_53.925000000000004_5_Test Postcode"
+
+
+def test_create_postcode_area_returns_error_for_missing_postcode_or_radius(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    # Missing postcode
+    resp = admin_request.post(
+        "areas.create_postcode_area",
+        _data={"radius": 5},
+        _expected_status=400,
+    )
+    assert resp == {"message": "Enter postcode and radius to create postcode area"}
+
+    # Missing radius
+    resp = admin_request.post(
+        "areas.create_postcode_area",
+        _data={"postcode": "Test Postcode"},
+        _expected_status=400,
+    )
+    assert resp == {"message": "Enter postcode and radius to create postcode area"}
+
+
+def test_create_coordinate_area_creates_valid_area_for_input(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21",
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE",
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840",
+    )
+    area, geography_version, geography_type = create_area_with_version_and_type(
+        geography_type_route="countries", geometry="".join(country_geometry)
+    )
+    resp = admin_request.post(
+        "areas.create_coordinate_area",
+        _data={
+            "first_coordinate": 528000,
+            "second_coordinate": 178000,
+            "coordinate_type": "easting_northing",
+            "radius": 5,
+        },
+        _expected_status=200,
+    )
+    assert resp["data"].startswith("POLYGON((")  # Returns POLYGON WKT string
+
+
+def test_create_coordinate_area_returns_error_for_external_coordinates(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21",
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE",
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840",
+    )
+    area, geography_version, geography_type = create_area_with_version_and_type(
+        geography_type_route="countries", geometry="".join(country_geometry)
+    )
+    resp = admin_request.post(
+        "areas.create_coordinate_area",
+        _data={
+            "first_coordinate": 0,
+            "second_coordinate": 0,
+            "coordinate_type": "easting_northing",
+            "radius": 5,
+        },
+        _expected_status=400,
+    )
+
+    assert resp == {"message": "Enter coordinates within the UK"}
+
+
+@pytest.mark.parametrize(
+    "data, expected_bool",
+    [
+        (
+            {"first_coordinate": 528000, "second_coordinate": 178000, "coordinate_type": "easting_northing"},
+            True,
+        ),
+        (
+            {
+                "first_coordinate": 0,
+                "second_coordinate": 0,
+                "coordinate_type": "easting_northing",
+            },
+            False,
+        ),
+        (
+            {"first_coordinate": 54, "second_coordinate": -2, "coordinate_type": "latitude_longitude"},
+            True,
+        ),
+        (
+            {
+                "first_coordinate": 0,
+                "second_coordinate": 0,
+                "coordinate_type": "latitude_longitude",
+            },
+            False,
+        ),
+    ],
+)
+def test_check_coordinates_valid_returns_whether_coordinates_valid_or_not(
+    notify_db_session, admin_request, sample_broadcast_service, data, expected_bool
+):
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21",
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE",
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840",
+    )
+    area, geography_version, geography_type = create_area_with_version_and_type(
+        geography_type_route="countries", geometry="".join(country_geometry)
+    )
+
+    resp_valid = admin_request.post(
+        "areas.check_coordinates_valid",
+        _data=data,
+        _expected_status=200,
+    )
+    assert resp_valid["data"] is expected_bool
+
+
+def test_build_alert_area_for_ids_returns_expected_area_dict(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    area1, _, _ = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, _, _ = create_area_with_version_and_type()
+
+    resp = admin_request.post(
+        "areas.build_alert_area_for_ids",
+        service_id=sample_broadcast_service.id,
+        _data={"area_ids": [str(area1.id), str(area2.id)]},
+        _expected_status=200,
+    )
+
+    assert resp == {
+        "aggregate_names": [area1.name, area2.name],
+        "ids": [str(area1.id), str(area2.id)],
+        "names": [area1.name, area2.name],
+        "simple_polygons": [[[54.65, -2.65], [54.65, 0.25], [53.2, 0.25], [53.2, -2.65], [54.65, -2.65]]],
+    }
+
+
+def test_add_areas_to_broadcast_message_returns_expected_dict(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    area1, _, _ = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, _, _ = create_area_with_version_and_type()
+    message = create_broadcast_message(
+        service=sample_broadcast_service,
+        reference="reference",
+        content="content",
+        areas={
+            "ids": ["Starting area ID"],
+            "simple_polygons": [[[50.1, 1.2], [50.12, 1.2], [50.13, 1.2]]],
+            "names": ["Starting area"],
+            "aggregate_names": ["Starting area"],
+        },
+    )
+    resp = admin_request.post(
+        "areas.add_areas",
+        service_id=sample_broadcast_service.id,
+        message_id=message.id,
+        message_type="broadcast",
+        _data={"area_ids": [str(area2.id)]},
+        _expected_status=200,
+    )
+
+    assert resp["areas"] == {
+        "aggregate_names": ["Starting area", area2.name],
+        "ids": ["Starting area ID", str(area2.id)],
+        "names": ["Starting area", area2.name],
+        "simple_polygons": [[[53.2, -2.65], [54.65, -2.65], [54.65, 0.25], [53.2, 0.25], [53.2, -2.65]]],
+    }
+
+
+def test_add_areas_to_template_returns_expected_dict(notify_db_session, admin_request, sample_broadcast_service):
+    area1, _, _ = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, _, _ = create_area_with_version_and_type()
+    template = create_template(
+        sample_broadcast_service,
+        template_name="Template Name",
+        template_type="broadcast",
+    )
+    resp = admin_request.post(
+        "areas.add_areas",
+        service_id=sample_broadcast_service.id,
+        message_id=template.id,
+        message_type="templates",
+        _data={"area_ids": [str(area2.id)]},
+        _expected_status=200,
+    )
+
+    assert resp["data"].get("areas") == {
+        "aggregate_names": [area2.name],
+        "ids": [str(area2.id)],
+        "names": [area2.name],
+        "simple_polygons": [[[53.2, -2.65], [53.2, 0.25], [54.65, 0.25], [54.65, -2.65], [53.2, -2.65]]],
+    }
+
+
+def test_add_custom_postcode_area_to_broadcast_message(notify_db_session, admin_request, sample_broadcast_service):
+    radius = 5
+    area, _, _ = create_area_with_version_and_type(
+        geographic_id="Test Postcode", geography_type_route="postcodes", name="Test Postcode"
+    )
+
+    message = create_broadcast_message(
+        service=sample_broadcast_service,
+        reference="reference",
+        content="content",
+        areas={
+            "ids": ["Starting area ID"],
+            "simple_polygons": [[[50.1, 1.2], [50.12, 1.2], [50.13, 1.2]]],
+            "names": ["Starting area"],
+            "aggregate_names": ["Starting area"],
+        },
+    )
+
+    resp = admin_request.post(
+        "areas.add_custom_areas",
+        service_id=sample_broadcast_service.id,
+        message_id=message.id,
+        message_type="broadcast",
+        type_name="postcodes",
+        _data={"postcode": "Test Postcode", "radius": radius},
+        _expected_status=200,
+    )
+    response_areas = resp["areas"]
+    assert response_areas["ids"] == ["Starting area ID", "postcodes_-1.2_53.925000000000004_5.0_Test Postcode"]
+    assert response_areas["aggregate_names"] == ["Starting area", f"{radius:g}km around the postcode {area.name}"]
+    assert response_areas["names"] == ["Starting area", f"{radius:g}km around the postcode {area.name}"]
+
+
+def test_add_custom_postcode_area_to_template(notify_db_session, admin_request, sample_broadcast_service):
+    area, _, _ = create_area_with_version_and_type(
+        geographic_id="Template Postcode", geography_type_route="postcodes", name="Template Postcode"
+    )
+    radius = 3.0
+
+    template = create_template(
+        sample_broadcast_service,
+        template_name="Template Name",
+        template_type="broadcast",
+        areas={
+            "ids": ["Starting area ID"],
+            "simple_polygons": [[[50.1, 1.2], [50.12, 1.2], [50.13, 1.2]]],
+            "names": ["Starting area"],
+            "aggregate_names": ["Starting area"],
+        },
+    )
+
+    resp = admin_request.post(
+        "areas.add_custom_areas",
+        service_id=sample_broadcast_service.id,
+        message_id=template.id,
+        message_type="templates",
+        type_name="postcodes",
+        _data={"postcode": "Template Postcode", "radius": radius},
+        _expected_status=200,
+    )
+    response_areas = resp.get("areas")
+    assert response_areas["ids"] == ["Starting area ID", "postcodes_-1.2_53.925000000000004_3.0_Template Postcode"]
+    assert response_areas["aggregate_names"] == ["Starting area", f"{radius:g}km around the postcode {area.name}"]
+    assert response_areas["names"] == ["Starting area", f"{radius:g}km around the postcode {area.name}"]
+
+
+def test_add_custom_coordinate_area_to_broadcast_message(notify_db_session, admin_request, sample_broadcast_service):
+    # Country geometry so coordinate validity works and parent lookup is possible
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21",
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE",
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840",
+    )
+    create_area_with_version_and_type(
+        geography_type_route="countries",
+        geometry="".join(country_geometry),
+    )
+
+    radius = 10.0
+
+    message = create_broadcast_message(
+        service=sample_broadcast_service,
+        reference="reference",
+        content="content",
+        areas={
+            "ids": ["Starting area"],
+            "simple_polygons": [[[50.1, 1.2], [50.12, 1.2], [50.13, 1.2]]],
+            "names": ["Starting area"],
+            "aggregate_names": ["Starting area"],
+        },
+    )
+
+    resp = admin_request.post(
+        "areas.add_custom_areas",
+        service_id=sample_broadcast_service.id,
+        message_id=message.id,
+        message_type="broadcast",
+        type_name="coordinates",
+        _data={
+            "first_coordinate": 54.0,
+            "second_coordinate": -2.0,
+            "coordinate_type": "latitude_longitude",
+            "radius": radius,
+        },
+        _expected_status=200,
+    )
+
+    response_areas = resp["areas"]
+    assert response_areas["ids"] == ["Starting area", "coordinates_54.0_-2.0_10.0_latitude_longitude"]
+    assert response_areas["aggregate_names"] == ["Starting area", "10km around 54.0 latitude, -2.0 longitude"]
+    assert response_areas["names"] == ["Starting area", "10km around 54.0 latitude, -2.0 longitude"]
+
+
+def test_add_custom_coordinate_area_to_template(notify_db_session, admin_request, sample_broadcast_service):
+    # Country geometry so coordinate validity works and parent lookup is possible
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21",
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE",
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840",
+    )
+    create_area_with_version_and_type(
+        geography_type_route="countries",
+        geometry="".join(country_geometry),
+    )
+
+    first_coordinate = 54.0
+    second_coordinate = -2.0
+    radius = 10.0
+
+    template = create_template(
+        sample_broadcast_service,
+        template_name="Template Name",
+        template_type="broadcast",
+        areas={
+            "ids": ["Starting area"],
+            "simple_polygons": [[[50.1, 1.2], [50.12, 1.2], [50.13, 1.2]]],
+            "names": ["Starting area"],
+            "aggregate_names": ["Starting area"],
+        },
+    )
+
+    resp = admin_request.post(
+        "areas.add_custom_areas",
+        service_id=sample_broadcast_service.id,
+        message_id=template.id,
+        message_type="templates",
+        type_name="coordinates",
+        _data={
+            "first_coordinate": first_coordinate,
+            "second_coordinate": second_coordinate,
+            "coordinate_type": "latitude_longitude",
+            "radius": radius,
+        },
+        _expected_status=200,
+    )
+
+    response_areas = resp.get("areas")
+    assert response_areas["ids"] == [
+        "Starting area",
+        f"coordinates_{first_coordinate}_{second_coordinate}_{radius}_latitude_longitude",
+    ]
+    assert response_areas["aggregate_names"] == [
+        "Starting area",
+        f"{radius:g}km around {first_coordinate} latitude, {second_coordinate} longitude",
+    ]
+    assert response_areas["names"] == [
+        "Starting area",
+        f"{radius:g}km around {first_coordinate} latitude, {second_coordinate} longitude",
+    ]
+
+
+def test_remove_area_from_broadcast_message_returns_expected_area_dict(
+    notify_db_session, admin_request, sample_broadcast_service
+):
+    area1, _, _ = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, _, _ = create_area_with_version_and_type()
+
+    message = create_broadcast_message(
+        service=sample_broadcast_service,
+        reference="reference",
+        content="content",
+        areas={
+            "aggregate_names": ["Starting area", area2.name],
+            "ids": ["Starting area ID", str(area2.id)],
+            "names": ["Starting area", area2.name],
+            "simple_polygons": [[[53.2, -2.65], [54.65, -2.65], [54.65, 0.25], [53.2, 0.25], [53.2, -2.65]]],
+        },
+    )
+
+    resp = admin_request.post(
+        "areas.remove_area",
+        service_id=sample_broadcast_service.id,
+        message_id=message.id,
+        message_type="broadcast",
+        _data={"area_id": "Starting area ID"},
+        _expected_status=200,
+    )
+
+    assert resp["areas"] == {
+        "aggregate_names": [area2.name],
+        "ids": [str(area2.id)],
+        "names": [area2.name],
+        "simple_polygons": [[[53.2, -2.65], [53.2, 0.25], [54.65, 0.25], [54.65, -2.65], [53.2, -2.65]]],
+    }

--- a/tests/app/areas/test_utils.py
+++ b/tests/app/areas/test_utils.py
@@ -1,0 +1,203 @@
+import pytest
+import shapely
+from emergency_alerts_utils.polygons import Polygons
+from geoalchemy2.shape import to_shape
+
+from app.areas.utils import (
+    add_custom_area_to_existing_areas,
+    area_response_json,
+    build_remaining_area_wkt,
+    ensure_valid_wkt,
+    generate_centroid_for_coordinate_area,
+    get_parent_area_name,
+    get_parent_geography_id,
+    validate_bulk_area_input,
+)
+from app.dao.areas_dao import (
+    dao_get_area_centroid,
+)
+from tests.app.db import (
+    create_area,
+    create_area_with_version_and_type,
+    create_broadcast_message,
+    create_geography_type,
+    create_geography_version,
+)
+
+
+class TestAreaObject:
+    # Dummy Area object necessary for some tests asserting how object processed
+    def __init__(self, id, name, parent_geography_id, geographic_id, geography_type_name):
+        self.id = id
+        self.name = name
+        self.parent_geography_id = parent_geography_id
+        self.geographic_id = geographic_id
+        self.geography_type_name = geography_type_name
+
+
+def test_area_response_json_returns_expected_json_for_area_object(notify_db_session):
+    area, _, geography_type = create_area_with_version_and_type(geography_type_name="TEST")
+    area_object = TestAreaObject(
+        id=area.id,
+        name=area.name,
+        parent_geography_id=area.parent_geography_id,
+        geographic_id=area.geographic_id,
+        geography_type_name=geography_type.name,
+    )
+    result = area_response_json(area_object)
+
+    assert result == {
+        "id": area.id,
+        "name": area.name,
+        "parent": area.parent_geography_id,
+        "geographic_id": area.geographic_id,
+        "geography_type": geography_type.name,
+    }
+
+
+def test_get_parent_geography_id_returns_expected_parent_geography_for_area(notify_db_session):
+    parent_type = create_geography_type(route="local_authorities")
+    parent_version = create_geography_version(geography_type_id=parent_type.id, state="active")
+    parent_area = create_area(
+        geography_type_id=parent_type.id,
+        geography_version_id=parent_version.id,
+        name="Parent LA",
+    )
+
+    parent_wkt = to_shape(parent_area.geometry).wkt
+    parent_id = get_parent_geography_id(parent_wkt, parent_type_name="local_authorities")
+
+    assert parent_id == parent_area.id
+
+
+def test_get_parent_geography_id_returns_None_if_unable_to_source_parent_area(notify_db_session):
+    # point that should not intersect any stored area (no areas created)
+    centroid = shapely.Point(-10.0, 0.0).wkt
+
+    parent_id = get_parent_geography_id(centroid, parent_type_name="local_authorities")
+    assert parent_id is None
+
+
+def test_add_custom_area_to_existing_areas_returns_expected_area(notify_db_session, sample_broadcast_service):
+    # Create an existing area and use its geometry for the initial polygons
+    area, _, _ = create_area_with_version_and_type()
+    polygons = Polygons.from_wkt(to_shape(area.geometry).wkt, utm_crs="EPSG:4326")
+    existing = {
+        "ids": [str(area.id)],
+        "names": [area.name],
+        "simple_polygons": polygons.polygons,
+    }
+    message = create_broadcast_message(
+        service=sample_broadcast_service,
+        reference="reference",
+        content="content",
+        areas=existing,
+    )
+
+    data = {
+        "radius": 5,
+        "first_coordinate": 54.0,
+        "second_coordinate": -2.0,
+        "coordinate_type": "latitude_longitude",
+    }
+
+    updated_message, error_response, status_code = add_custom_area_to_existing_areas(
+        message,
+        type_name="coordinates",
+        data=data,
+    )
+
+    assert updated_message.areas == {
+        "aggregate_names": ["Test name", "5km around 54.0 latitude, -2.0 longitude"],
+        "ids": [str(area.id), "coordinates_54.0_-2.0_5.0_latitude_longitude"],
+        "names": ["Test name", "5km around 54.0 latitude, -2.0 longitude"],
+        "simple_polygons": [[[54.65, -2.65], [54.65, 0.25], [53.2, 0.25], [53.2, -2.65], [54.65, -2.65]]],
+    }
+
+
+def test_get_parent_area_name_returns_expected_string(notify_db_session):
+    parent_type = create_geography_type(route="local_authorities")
+    parent_version = create_geography_version(geography_type_id=parent_type.id, state="active")
+    parent_area = create_area(
+        geography_type_id=parent_type.id,
+        geography_version_id=parent_version.id,
+        name="Leeds, City of",
+    )
+
+    centroid = dao_get_area_centroid(parent_area.id)
+    parent_area_name = get_parent_area_name(centroid)
+
+    assert parent_area_name == "City of Leeds"
+
+
+def test_generate_centroid_for_coordinate_area_returns_expected_geometry():
+    centroid_latlon = generate_centroid_for_coordinate_area(
+        first_coordinate=54.0,
+        second_coordinate=-2.0,
+        coordinate_type="latitude_longitude",
+    )
+    geom = shapely.wkt.loads(centroid_latlon)
+    assert geom.geom_type == "Point"
+    assert pytest.approx(geom.y, rel=1e-6) == 54.0
+    assert pytest.approx(geom.x, rel=1e-6) == -2.0
+
+    centroid_en = generate_centroid_for_coordinate_area(
+        first_coordinate=528000,
+        second_coordinate=178000,
+        coordinate_type="easting_northing",
+    )
+    geom_en = shapely.wkt.loads(centroid_en)
+    assert geom_en.geom_type == "Point"
+
+
+def test_ensure_valid_wkt_validates_wkt_correctly():
+    # valid polygon remains unchanged
+    valid_wkt = shapely.Point(-2.0, 54.0).buffer(0.1).wkt
+    result = ensure_valid_wkt(valid_wkt)
+    assert isinstance(result, str)
+    assert result == valid_wkt
+
+    # deliberately construct an invalid self‑intersecting polygon and ensure it is repaired
+    coords = [(0, 0), (1, 1), (1, 0), (0, 1), (0, 0)]
+    invalid_geom = shapely.Polygon(coords)
+    assert not invalid_geom.is_valid
+    fixed = ensure_valid_wkt(invalid_geom.wkt)
+    # ensure_valid_wkt returns either wkt string or (response, status)
+    assert isinstance(fixed, str)
+    repaired_geom = shapely.wkt.loads(fixed)
+    assert repaired_geom.is_valid
+
+
+def test_validate_bulk_area_input_returns_correct_error_message_for_input():
+    # missing data
+    assert validate_bulk_area_input([], "local_authorities") == "Enter at least 1 local authority"
+
+    # duplicates
+    assert validate_bulk_area_input(["Area 1", "Area 1"], "local_authorities") == "All local authorities must be unique"
+
+    # exceeds limit
+    too_many = [f"Area {i}" for i in range(26)]
+    assert (
+        validate_bulk_area_input(too_many, "local_authorities")
+        == "Maximum of 25 local authorities allowed as a list in one emergency alert"
+    )
+
+    # valid list returns None
+    assert validate_bulk_area_input(["Area 1", "Area 2"], "local_authorities") is None
+
+
+def test_build_remaining_area_wkt_returns_expected_wkt(notify_db_session):
+    # creates two stored areas
+    area1, _, _ = create_area_with_version_and_type()
+    area2, _, _ = create_area_with_version_and_type(geography_type_name="Test Type", geography_type_route="Test")
+
+    existing_ids = [str(area1.id), str(area2.id)]
+    remaining_ids, polygons, combined_source_ids = build_remaining_area_wkt(
+        existing_ids,
+        area_id_to_remove=str(area1.id),
+    )
+
+    assert remaining_ids == [str(area2.id)]
+    assert combined_source_ids == [str(area2.id)]
+    assert isinstance(polygons, list)
+    assert len(polygons) > 0

--- a/tests/app/dao/test_areas_dao.py
+++ b/tests/app/dao/test_areas_dao.py
@@ -1,0 +1,384 @@
+import uuid
+
+import pytest
+from geoalchemy2.shape import to_shape
+
+from app.dao.areas_dao import (
+    dao_check_coordinates_valid,
+    dao_combine_geometries,
+    dao_create_area,
+    dao_create_circle_area,
+    dao_get_area_by_id,
+    dao_get_area_centroid,
+    dao_get_areas_by_ids,
+    dao_get_areas_by_names,
+    dao_get_areas_for_geography_type,
+    dao_get_child_areas_for_parent_geography_id,
+    dao_get_dominant_parent_geography_id,
+    dao_get_grandparent_areas,
+    dao_get_latest_active_version_for_type_route,
+    dao_get_latest_area_by_geographic_id,
+    dao_get_latest_geography_types_with_count_and_examples,
+    dao_get_latest_geography_version_number,
+    dao_get_latest_geography_versions,
+)
+from tests.app.db import (
+    create_area,
+    create_area_with_version_and_type,
+    create_geography_type,
+    create_geography_version,
+)
+
+
+def test_dao_get_latest_geography_version_number_returns_expected_version(notify_db_session):
+    geography_type = create_geography_type(route="local_authorities")
+    create_geography_version(geography_type_id=geography_type.id, version="1.0.0", state="active")
+    newer = create_geography_version(geography_type_id=geography_type.id, version="2.0.0", state="active")
+    # inactive shouldn't be returned
+    create_geography_version(geography_type_id=geography_type.id, version="3.0.0", state="inactive")
+
+    version_number = dao_get_latest_geography_version_number()
+
+    assert version_number == newer.version
+
+
+def test_dao_get_latest_geography_versions_returns_latest_versions(notify_db_session):
+    type1 = create_geography_type(route="local_authorities", name="Local authorities")
+    type2 = create_geography_type(route="wards", name="Wards")
+
+    create_geography_version(geography_type_id=type1.id, version="1.0.0", state="active")
+    version1_new = create_geography_version(geography_type_id=type1.id, version="2.0.0", state="active")
+    version2_new = create_geography_version(geography_type_id=type2.id, version="2.0.0", state="active")
+
+    # Latest version number across all active types is 2.0.0
+    latest_versions = dao_get_latest_geography_versions()
+
+    assert {v.id for v in latest_versions} == {version1_new.id, version2_new.id}
+
+
+def test_dao_get_latest_geography_versions_returns_empty_list_if_no_active_versions(notify_db_session):
+    type1 = create_geography_type(route="local_authorities")
+    create_geography_version(geography_type_id=type1.id, version="1.0.0", state="inactive")
+
+    result = dao_get_latest_geography_versions()
+    assert result == []
+
+
+def test_dao_get_latest_active_version_for_type_route_returns_expected_version_for_type(notify_db_session):
+    geography_type = create_geography_type(route="local_authorities")
+    create_geography_version(geography_type_id=geography_type.id, version="1.0.0", state="active")
+    v_latest = create_geography_version(geography_type_id=geography_type.id, version="2.0.0", state="active")
+
+    found = dao_get_latest_active_version_for_type_route("local_authorities")
+    assert found.id == v_latest.id
+
+
+def test_dao_get_areas_for_geography_type_returns_all_expected_areas_for_type(notify_db_session):
+    geography_type = create_geography_type(name="Local authorities", route="local_authorities")
+    gv1 = create_geography_version(geography_type_id=geography_type.id, version="1.0.0", state="active")
+    gv0 = create_geography_version(geography_type_id=geography_type.id, version="0.9.0", state="active")
+
+    area_latest1 = create_area(geography_type_id=geography_type.id, geography_version_id=gv1.id, name="Area A")
+    area_latest2 = create_area(geography_type_id=geography_type.id, geography_version_id=gv1.id, name="Area B")
+    create_area(geography_type_id=geography_type.id, geography_version_id=gv0.id, name="Area Old")
+
+    areas = dao_get_areas_for_geography_type("local_authorities")
+
+    # Only latest version's areas, ordered by name
+    assert [a.name for a in areas] == ["Area A", "Area B"]
+    assert {a.id for a in areas} == {area_latest1.id, area_latest2.id}
+
+
+def test_dao_get_areas_for_geography_type_returns_empty_list_if_no_active_versions(notify_db_session):
+    # geography type exists, but no active version
+    geography_type = create_geography_type(name="Local authorities", route="local_authorities")
+    create_geography_version(geography_type_id=geography_type.id, version="1.0.0", state="inactive")
+
+    areas = dao_get_areas_for_geography_type("local_authorities")
+    assert areas == []
+
+
+def test_dao_get_child_areas_for_parent_geography_id_returns_all_expected_child_areas_for_parent_area(
+    notify_db_session,
+):
+    la_type = create_geography_type(route="local_authorities")
+    la_version = create_geography_version(geography_type_id=la_type.id, version="1.0.0", state="active")
+    ward_type = create_geography_type(route="wards", name="Wards")
+    ward_version = create_geography_version(geography_type_id=ward_type.id, version="1.0.0", state="active")
+
+    parent = create_area(geography_type_id=la_type.id, geography_version_id=la_version.id, geographic_id="parent-id")
+    child_la = create_area(
+        parent_geography_id=parent.geographic_id,
+        geography_type_id=la_type.id,
+        geography_version_id=la_version.id,
+        geographic_id="child-la",
+    )
+    child_ward = create_area(
+        parent_geography_id=parent.geographic_id,
+        geography_type_id=ward_type.id,
+        geography_version_id=ward_version.id,
+        geographic_id="child-ward",
+    )
+
+    children = dao_get_child_areas_for_parent_geography_id(parent.geographic_id)
+
+    assert [area.geographic_id for area in children] == [child_la.geographic_id, child_ward.geographic_id]
+
+
+def test_dao_get_child_areas_for_parent_geography_id_returns_empty_list_if_no_active_versions(notify_db_session):
+    la_type = create_geography_type(route="local_authorities")
+    la_version = create_geography_version(geography_type_id=la_type.id, version="1.0.0", state="inactive")
+
+    parent = create_area(geography_type_id=la_type.id, geography_version_id=la_version.id, geographic_id="parent-id")
+    create_area(
+        parent_geography_id=parent.geographic_id,
+        geography_type_id=la_type.id,
+        geography_version_id=la_version.id,
+        geographic_id="child-id",
+    )
+
+    children = dao_get_child_areas_for_parent_geography_id(parent.geographic_id)
+    assert children == []
+
+
+def test_dao_get_grandparent_areas_returns_only_areas_that_are_grandparents(notify_db_session):
+    la_type = create_geography_type(route="local_authorities")
+    la_version = create_geography_version(geography_type_id=la_type.id, version="1.0.0", state="active")
+
+    ward_type = create_geography_type(route="wards", name="Wards")
+    create_geography_version(geography_type_id=ward_type.id, version="1.0.0", state="active")
+
+    grandparent_area = create_area(
+        geography_type_id=la_type.id, geography_version_id=la_version.id, geographic_id="grandparent"
+    )
+    parent_area = create_area(
+        parent_geography_id=grandparent_area.geographic_id,
+        geography_type_id=la_type.id,
+        geography_version_id=la_version.id,
+        geographic_id="parent",
+    )
+    create_area(
+        parent_geography_id=parent_area.geographic_id,
+        geography_type_id=la_type.id,
+        geography_version_id=la_version.id,
+        geographic_id="child",
+    )
+
+    non_grandparent_area = create_area(
+        geography_type_id=la_type.id, geography_version_id=la_version.id, geographic_id="non-parent"
+    )
+    create_area(  # parent_of_non_grandparent
+        parent_geography_id=non_grandparent_area.geographic_id,
+        geography_type_id=la_type.id,
+        geography_version_id=la_version.id,
+    )
+
+    grandparent_ids = [row[0] for row in dao_get_grandparent_areas()]
+    assert str(grandparent_area.id) in {str(i) for i in grandparent_ids}
+    assert str(non_grandparent_area.id) not in {str(i) for i in grandparent_ids}
+
+
+def test_dao_get_latest_area_by_geographic_id_returns_expected_area(notify_db_session):
+    area, geography_version, geography_type = create_area_with_version_and_type()
+    result = dao_get_latest_area_by_geographic_id(area.geographic_id)
+
+    assert result is not None
+    assert result.id == area.id
+    assert result.geographic_id == area.geographic_id
+    assert result.name == area.name
+
+
+def test_dao_get_latest_area_by_geographic_id_returns_None_if_no_active_area_exists(notify_db_session):
+    # create area but mark its version inactive so it shouldn't be returned
+    geography_type = create_geography_type()
+    gv_inactive = create_geography_version(geography_type_id=geography_type.id, version="1.0.0", state="inactive")
+    area = create_area(geography_type_id=geography_type.id, geography_version_id=gv_inactive.id)
+
+    result = dao_get_latest_area_by_geographic_id(area.geographic_id)
+    assert result is None
+
+
+def test_dao_get_latest_area_by_geographic_id_with_type_returns_expected_area(notify_db_session):
+    area, geography_version, geography_type = create_area_with_version_and_type(geography_type_route="postcodes")
+    result = dao_get_latest_area_by_geographic_id(area.geographic_id, type_name="postcodes")
+
+    assert result is not None
+    assert result.id == area.id
+    assert result.geography_type_name == geography_type.route
+
+
+def test_dao_get_areas_by_names_returns_expected_areas(notify_db_session):
+    geography_type = create_geography_type(name="Local authorities", route="local_authorities")
+    geography_version = create_geography_version(geography_type_id=geography_type.id)
+
+    area1 = create_area(
+        geography_type_id=geography_type.id,
+        geography_version_id=geography_version.id,
+        name="Local authority 1",
+    )
+    area2 = create_area(
+        geography_type_id=geography_type.id,
+        geography_version_id=geography_version.id,
+        name="Local authority 2",
+    )
+
+    areas = dao_get_areas_by_names(["Local authority 1", "Local authority 2"], "local_authorities")
+
+    assert {a.id for a in areas} == {area1.id, area2.id}
+
+
+def test_dao_get_area_by_id_returns_expected_area_or_None(notify_db_session):
+    area, _, geography_type = create_area_with_version_and_type()
+    found = dao_get_area_by_id(area.id)
+
+    assert found is not None
+    assert found.id == area.id
+    assert found.geographic_id == area.geographic_id
+    assert found.geography_type_name == geography_type.route
+
+    missing = dao_get_area_by_id(uuid.uuid4())
+    assert missing is None
+
+
+def test_dao_get_areas_by_ids_returns_expected_areas(notify_db_session):
+    area1, _, _ = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, _, _ = create_area_with_version_and_type()
+
+    areas = dao_get_areas_by_ids([str(area1.id), str(area2.id)])
+    ids = [a.id for a in areas]
+
+    assert set(ids) == {area1.id, area2.id}
+
+
+def test_dao_get_latest_geography_types_with_count_and_examples_returns_expected_data_for_type(
+    notify_db_session,
+):
+    area, geography_version, geography_type = create_area_with_version_and_type(
+        geography_type_name="Local authorities",
+        geography_type_route="local_authorities",
+    )
+
+    results = dao_get_latest_geography_types_with_count_and_examples()
+    assert len(results) == 1
+
+    row = results[0]
+    assert row.id == geography_type.id
+    assert row.geography_type_name == geography_type.name
+    assert row.route == geography_type.route
+    assert int(row.area_count) == 1
+    assert list(row.areas) == [area.name]
+
+
+def test_dao_create_area_returns_expected_area_wkt(notify_db_session):
+    area1, _, _ = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, _, _ = create_area_with_version_and_type()
+
+    wkt1 = to_shape(area1.geometry).wkt
+    wkt2 = to_shape(area2.geometry).wkt
+
+    combined = dao_create_area([wkt1, wkt2])
+
+    assert isinstance(combined, str)
+    assert combined.startswith("POLYGON(")
+
+
+def test_dao_get_area_centroid_returns_expected_wkt(notify_db_session):
+    area, _, _ = create_area_with_version_and_type()
+    centroid = dao_get_area_centroid(area.id)
+
+    # matches what the REST tests expect for the default geometry
+    assert centroid == "POINT(-1.2 53.925000000000004)"
+
+
+def test_dao_get_area_centroid_returns_None_if_no_area_id_provided(notify_db_session):
+    geography_type = create_geography_type()
+    geography_version = create_geography_version(geography_type_id=geography_type.id)
+    create_area(geography_type_id=geography_type.id, geography_version_id=geography_version.id)
+
+    centroid = dao_get_area_centroid(None)
+    assert centroid is None
+
+
+def test_dao_create_circle_area_returns_expected_wkt(notify_db_session):
+    # use a simple point centroid from the default area
+    area, _, _ = create_area_with_version_and_type()
+    centroid = dao_get_area_centroid(area.id)
+
+    circle_wkt = dao_create_circle_area(centroid, radius=5)
+
+    assert isinstance(circle_wkt, str)
+    assert circle_wkt.startswith("POLYGON((")
+
+
+def test_dao_combine_geometries_returns_expected_wkt(notify_db_session):
+    area1, _, _ = create_area_with_version_and_type(
+        geography_type_name="Test type", geography_type_route="Test route 2"
+    )
+    area2, _, _ = create_area_with_version_and_type()
+
+    wkt1 = to_shape(area1.geometry).wkt
+    wkt2 = to_shape(area2.geometry).wkt
+
+    combined = dao_combine_geometries(wkt1, wkt2)
+
+    assert isinstance(combined, str)
+    assert combined.startswith("POLYGON(") or combined.startswith("MULTIPOLYGON(")
+
+
+@pytest.mark.parametrize(
+    "data, expected_bool",
+    [
+        ({"first": 528000, "second": 178000, "coordinate_type": "easting_northing"}, True),
+        ({"first": 0, "second": 0, "coordinate_type": "easting_northing"}, False),
+        ({"first": 54, "second": -2, "coordinate_type": "latitude_longitude"}, True),
+        ({"first": 0, "second": 0, "coordinate_type": "latitude_longitude"}, False),
+    ],
+)
+def test_dao_check_coordinates_valid_returns_expected_bool_for_centroid(
+    notify_db_session,
+    data,
+    expected_bool,
+):
+    # set up a country polygon so validity checks have something to contain/ exclude
+    country_geometry = (
+        "0103000020E61000000100000005000000CDCCCCCCCC4C21"
+        "C0CDCCCCCCCCEC48407B14AE47E17AFC3FCDCCCCCCCCEC48407B14AE47E17AFC3FAE"
+        "47E17A146E4E40CDCCCCCCCC4C21C0AE47E17A146E4E40CDCCCCCCCC4C21C0CDCCCCCCCCEC4840"
+    )
+    create_area_with_version_and_type(
+        geography_type_route="countries",
+        geometry=country_geometry,
+    )
+
+    valid = dao_check_coordinates_valid(data["first"], data["second"], data["coordinate_type"])
+    assert valid is expected_bool
+
+
+def test_dao_get_dominant_parent_geography_id_returns_expected_parent_area_geography_id(
+    notify_db_session,
+):
+    # Parent type
+    la_type = create_geography_type(name="Local authorities", route="local_authorities")
+    la_version = create_geography_version(geography_type_id=la_type.id)
+
+    parent1 = create_area(
+        geography_type_id=la_type.id,
+        geography_version_id=la_version.id,
+        name="Parent 1",
+    )
+    create_area(
+        geography_type_id=la_type.id,
+        geography_version_id=la_version.id,
+        name="Parent 2",
+    )
+
+    # Use geometry of parent1 as the child area WKT so it should overlap parent1 most
+    parent1_wkt = to_shape(parent1.geometry).wkt
+
+    dominant_id = dao_get_dominant_parent_geography_id(parent1_wkt, parent_type_name="local_authorities")
+
+    assert dominant_id == parent1.id

--- a/tests/app/db.py
+++ b/tests/app/db.py
@@ -32,6 +32,9 @@ from app.models import (
     Domain,
     FailedLogin,
     FeatureToggle,
+    GeographyPolygons,
+    GeographyType,
+    GeographyVersion,
     InvitedOrganisationUser,
     InvitedUser,
     Organisation,
@@ -521,3 +524,104 @@ def create_publish_task(
     db.session.add(publish_task)
     db.session.commit()
     return publish_task
+
+
+def create_geography_version(
+    id=None, geography_type_id=None, created_at=None, version="1.0.0", source_url="test.csv", state="active"
+):
+    version = GeographyVersion(
+        id=id or str(uuid.uuid4()),
+        geography_type_id=geography_type_id or str(uuid.uuid4()),
+        created_at=created_at or datetime.now(),
+        version=version,
+        source_url=source_url,
+        state=state,
+    )
+    db.session.add(version)
+    db.session.commit()
+    return version
+
+
+def create_geography_type(id=None, name=None, route=None, name_singular="Test singular area"):
+    type = GeographyType(
+        id=id or str(uuid.uuid4()), name=name or "Test name", route=route or "Test route", name_singular=name_singular
+    )
+    db.session.add(type)
+    db.session.commit()
+    return type
+
+
+def create_area(
+    id=None,
+    geographic_id="Test geographic id",
+    name="Test name",
+    geometry=None,
+    parent_geography_id="Test parent geography id",
+    geography_version_id=None,
+    geography_type_id=None,
+):
+    if geometry is None:
+        # london area WKT
+        geometry = (
+            "0103000020E61000000100000005000000A4",
+            "703D0AD7A3C0BFE17A14AE47C14940B81E85E",
+            "B51B8BEBFE17A14AE47C14940B81E85EB51B8",
+            "BEBF0000000000C04940A4703D0AD7A3C0BF0",
+            "000000000C04940A4703D0AD7A3C0BFE17A14",
+            "AE47C14940",
+        )
+    area = GeographyPolygons(
+        id=id or uuid.uuid4(),
+        geographic_id=geographic_id,
+        name=name,
+        geometry="".join(geometry),
+        parent_geography_id=parent_geography_id,
+        geography_version_id=geography_version_id,
+        geography_type_id=geography_type_id,
+    )
+    db.session.add(area)
+    db.session.commit()
+    return area
+
+
+def create_area_with_version_and_type(
+    id=None,
+    geographic_id="Test geographic id",
+    name="Test name",
+    geometry=None,
+    parent_geography_id="Test parent geography id",
+    geography_version_id=None,
+    geography_type_id=None,
+    geography_type_name=None,
+    geography_type_route=None,
+):
+    # Ensure we always have a GeographyType and GeographyVersion, and use their UUID ids directly
+    if geography_type_id is None:
+        geography_type = create_geography_type(name=geography_type_name, route=geography_type_route)
+        geography_type_id = str(geography_type.id)
+
+    if geography_version_id is None:
+        geography_version = create_geography_version(geography_type_id=geography_type_id)
+        geography_version_id = str(geography_version.id)
+
+    if geometry is None:
+        # Dummy WKT geomtry - Yorkshire
+        geometry = (
+            "0103000020E610000001000000050000003333333",
+            "3333305C09A99999999994A40000000000000D03F9A99999999994A",
+            "40000000000000D03F3333333333534B4033333333333305C033333",
+            "33333534B4033333333333305C09A99999999994A40",
+        )
+
+    area = GeographyPolygons(
+        id=id or uuid.uuid4(),
+        geographic_id=geographic_id,
+        name=name,
+        geometry="".join(geometry),
+        parent_geography_id=parent_geography_id,
+        geography_version_id=geography_version_id,
+        geography_type_id=geography_type_id,
+    )
+    db.session.add(area)
+    db.session.commit()
+    return area, geography_version, geography_type


### PR DESCRIPTION
This PR consists of the following changes:
- Addition of rest and utils functions, adding `areas` routes for Admin application - allowing us to return areas data from DB
- Addition of DAO functions allowing us to interact with the data stored in `geography_polygons`, `geography_version` and `geography_type`
- Addition of relevant unit tests

`utils:EAS-3028-Polygons-adjustments`