### PR TITLE
EAS-3229: Provide BroadcastEvent ID instead of BroadcastProviderMessage ID to CBC

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -138,7 +138,10 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
     messages = dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id)
 
     # Create a structure like:
-    # { "<mno>": { "alertBroadcastEventId": "", "alert": [{}], "cancelBroadcastEventId": "", "cancel": [{}] } }
+    # { "<mno>": {
+    #   "alertBroadcastEventId": "", "alertBroadcastProviderMessageId": "", "alert": [{}],
+    #   "cancelBroadcastEventId": "", "cancelBroadcastProviderMessageId", "", "cancel": [{}]
+    # } }
     # (yes, the broadcast event ID will be the same for each MNO - it's to keep the data structure backwards compatible)
 
     result = {}
@@ -147,8 +150,10 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
             broadcast_provider_message.provider,
             {
                 "alertBroadcastEventId": None,
+                "alertBroadcastProviderMessageId": None,
                 BroadcastEventMessageType.ALERT: [],
                 "cancelBroadcastEventId": None,
+                "cancelBroadcastProviderMessageId": None,
                 BroadcastEventMessageType.CANCEL: [],
             },
         )
@@ -167,10 +172,18 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
             result[broadcast_provider_message.provider][
                 "alertBroadcastEventId"
             ] = broadcast_provider_message.broadcast_event_id
+
+            result[broadcast_provider_message.provider][
+                "alertBroadcastProviderMessageId"
+            ] = broadcast_provider_message.id
         elif broadcast_event_message_type == "cancel":
             result[broadcast_provider_message.provider][
                 "cancelBroadcastEventId"
             ] = broadcast_provider_message.broadcast_event_id
+
+            result[broadcast_provider_message.provider][
+                "cancelBroadcastProviderMessageId"
+            ] = broadcast_provider_message.id
 
         result[broadcast_provider_message.provider][broadcast_event_message_type] = statuses
 

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -138,13 +138,19 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
     messages = dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id)
 
     # Create a structure like:
-    # { "<mno>": { "alert": [{}], "cancel": [{}] } }
+    # { "<mno>": { "alertBroadcastEventId": "", "alert": [{}], "cancelBroadcastEventId": "", "cancel": [{}] } }
+    # (yes, the broadcast event ID will be the same for each MNO - it's to keep the data structure backwards compatible)
 
     result = {}
     for broadcast_provider_message, broadcast_event_message_type in messages:
         result.setdefault(
             broadcast_provider_message.provider,
-            {BroadcastEventMessageType.ALERT: [], BroadcastEventMessageType.CANCEL: []},
+            {
+                "alertBroadcastEventId": None,
+                BroadcastEventMessageType.ALERT: [],
+                "cancelBroadcastEventId": None,
+                BroadcastEventMessageType.CANCEL: [],
+            },
         )
 
         # This relationship has an order_by and thus should be in old to new order
@@ -157,11 +163,21 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
             for status_db in broadcast_provider_message.statuses
         ]
 
+        if broadcast_event_message_type == "alert":
+            result[broadcast_provider_message.provider][
+                "alertBroadcastEventId"
+            ] = broadcast_provider_message.broadcast_event_id
+        elif broadcast_event_message_type == "cancel":
+            result[broadcast_provider_message.provider][
+                "cancelBroadcastEventId"
+            ] = broadcast_provider_message.broadcast_event_id
+
         result[broadcast_provider_message.provider][broadcast_event_message_type] = statuses
 
     return jsonify(result)
 
 
+# Deprecated: Only used by functional tests prior to migration to provider-statuses
 @broadcast_message_blueprint.route("/<uuid:broadcast_message_id>/provider-messages", methods=["GET"])
 def get_broadcast_provider_messages(service_id, broadcast_message_id):
     messages = dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id)

--- a/app/clients/cbc_proxy.py
+++ b/app/clients/cbc_proxy.py
@@ -3,6 +3,7 @@ import os
 import uuid
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 
 import boto3
 import botocore
@@ -12,6 +13,9 @@ from sqlalchemy.schema import Sequence
 
 from app.config import BroadcastProvider
 from app.utils import DATETIME_FORMAT, format_sequential_number
+
+if TYPE_CHECKING:
+    from app.models import BroadcastEvent
 
 # The variable names in this file have specific meaning in a CAP message
 #
@@ -25,9 +29,10 @@ from app.utils import DATETIME_FORMAT, format_sequential_number
 # * description is a string which populates the areaDesc field
 # * polygon is a list of lat/long pairs
 #
-# previous_provider_messages is a list of previous events (models.py::BroadcastProviderMessage)
+# previous_events is a list of previous events (models.py::BroadcastEvent)
 # ie a Cancel message would have a unique event but have the event of
-#    the preceeding Alert message in the previous_provider_messages field
+#    the preceeding Alert message in the previous_events field
+#    so that it can report the ID of the alert it's cancelling
 
 aws_region = os.environ.get("AWS_REGION", "eu-west-2")
 
@@ -46,7 +51,7 @@ class CBCProxyClient:
                 self._arn_prefix = app.config.get("CBC_ACCOUNT_NUMBER") + ":function:"
             self._lambda_client = boto3.client("lambda", region_name=aws_region)
 
-    def get_proxy(self, provider):
+    def get_proxy(self, provider) -> "CBCProxyClientBase":
         proxy_classes = {
             BroadcastProvider.EE: CBCProxyEE,
             BroadcastProvider.THREE: CBCProxyThree,
@@ -121,7 +126,7 @@ class CBCProxyClientBase(ABC):
     def update_and_send_broadcast(
         self,
         identifier,
-        previous_provider_messages,
+        previous_events: list["BroadcastEvent"],
         headline,
         description,
         areas,
@@ -134,7 +139,15 @@ class CBCProxyClientBase(ABC):
 
     @abstractmethod
     def cancel_broadcast(
-        self, identifier, previous_provider_messages, headline, description, areas, sent, expires, message_number=None
+        self,
+        identifier,
+        previous_events: list["BroadcastEvent"],
+        headline,
+        description,
+        areas,
+        sent,
+        expires,
+        message_number=None,
     ):
         pass
 
@@ -299,14 +312,14 @@ class CBCProxyOne2ManyClient(CBCProxyClientBase):
         }
         self._invoke_lambdas_with_routing(payload=payload)
 
-    def cancel_broadcast(self, identifier, previous_provider_messages, sent, message_number=None):
+    def cancel_broadcast(self, identifier, previous_events: list["BroadcastEvent"], sent, message_number=None):
         payload = {
             "message_type": "cancel",
             "identifier": identifier,
             "message_format": "cap",
             "references": [
-                {"message_id": str(message.id), "sent": message.created_at.strftime(DATETIME_FORMAT)}
-                for message in previous_provider_messages
+                {"message_id": str(event.id), "sent": event.created_at.strftime(DATETIME_FORMAT)}
+                for event in previous_events
             ],
             "sent": sent,
         }
@@ -315,7 +328,7 @@ class CBCProxyOne2ManyClient(CBCProxyClientBase):
     def update_and_send_broadcast(
         self,
         identifier,
-        previous_provider_messages,
+        previous_events: list["BroadcastEvent"],
         headline,
         description,
         areas,
@@ -393,7 +406,7 @@ class CBCProxyVodafone(CBCProxyClientBase):
         }
         self._invoke_lambdas_with_routing(payload=payload)
 
-    def cancel_broadcast(self, identifier, previous_provider_messages, sent, message_number):
+    def cancel_broadcast(self, identifier, previous_events: list["BroadcastEvent"], sent, message_number):
         payload = {
             "message_type": "cancel",
             "identifier": identifier,
@@ -401,11 +414,13 @@ class CBCProxyVodafone(CBCProxyClientBase):
             "message_format": "ibag",
             "references": [
                 {
-                    "message_id": str(message.id),
-                    "message_number": format_sequential_number(message.message_number),
-                    "sent": message.created_at.strftime(DATETIME_FORMAT),
+                    "message_id": str(event.id),
+                    "message_number": format_sequential_number(
+                        event.get_provider_message(BroadcastProvider.VODAFONE).message_number
+                    ),
+                    "sent": event.created_at.strftime(DATETIME_FORMAT),
                 }
-                for message in previous_provider_messages
+                for event in previous_events
             ],
             "sent": sent,
         }
@@ -414,7 +429,7 @@ class CBCProxyVodafone(CBCProxyClientBase):
     def update_and_send_broadcast(
         self,
         identifier,
-        previous_provider_messages,
+        previous_events: list["BroadcastEvent"],
         headline,
         description,
         areas,

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -161,7 +161,9 @@ def dao_get_broadcast_provider_messages_by_broadcast_message_ids(
     )
 
 
-def dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id):
+def dao_get_broadcast_provider_messages_by_broadcast_message_id(
+    broadcast_message_id,
+) -> list[tuple[BroadcastProviderMessage, str]]:
     return (
         db.session.query(
             BroadcastProviderMessage,

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -405,7 +405,7 @@ def dao_delete_records_for_broadcast(service, message_id, dry_run=False):
     return counter
 
 
-def get_earlier_events_for_broadcast_event(broadcast_event_id):
+def get_earlier_events_for_broadcast_event(broadcast_event_id) -> list[BroadcastEvent]:
     """
     This is used to build up the references list.
     """

--- a/app/models.py
+++ b/app/models.py
@@ -1143,32 +1143,6 @@ class BroadcastEvent(db.Model):
             None,
         )
 
-    def get_earlier_provider_messages(self, provider):
-        """
-        Get the previous message for a provider. These are different per provider, as the identifiers are different.
-        Return the full provider_message object rather than just an identifier, since the different providers expect
-        reference to contain different things - let the cbc_proxy work out what information is relevant.
-        """
-        from app.dao.broadcast_message_dao import (
-            get_earlier_events_for_broadcast_event,
-        )
-
-        earlier_events = [event for event in get_earlier_events_for_broadcast_event(self.id)]
-        ret = []
-        for event in earlier_events:
-            provider_message = event.get_provider_message(provider)
-            if provider_message is None:
-                # TODO: We should figure out what to do if a previous message hasn't been sent out yet.
-                # We don't want to not cancel a message just because it's stuck in a queue somewhere.
-                # This exception should probably be named, and then should be caught further up and handled
-                # appropriately.
-                raise Exception(
-                    f"Cannot get earlier message references for event {self.id}, previous event {event.id} has not "
-                    + f' been sent to provider "{provider}" yet'
-                )
-            ret.append(provider_message)
-        return ret
-
     def serialize(self):
         return {
             "id": str(self.id),

--- a/app/tasks/broadcast_message_tasks.py
+++ b/app/tasks/broadcast_message_tasks.py
@@ -11,6 +11,7 @@ from app.dao.broadcast_message_dao import (
     add_broadcast_provider_message_status,
     create_broadcast_provider_message,
     dao_get_broadcast_event_by_id,
+    get_earlier_events_for_broadcast_event,
 )
 from app.models import (
     BROADCAST_PROVIDER_STATUS_ACK,
@@ -213,7 +214,7 @@ def send_broadcast_provider_message(*, broadcast_event_id, provider):
                     headline=HEADLINE,
                     description=broadcast_event.transmitted_content["body"],
                     areas=areas,
-                    previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
+                    previous_events=get_earlier_events_for_broadcast_event(broadcast_event.id),
                     sent=broadcast_event.sent_at_as_cap_datetime_string,
                     expires=broadcast_event.transmitted_finishes_at_as_cap_datetime_string,
                     # We think an alert update should always go out on the same channel that created the alert
@@ -228,7 +229,7 @@ def send_broadcast_provider_message(*, broadcast_event_id, provider):
                 cbc_proxy_provider_client.cancel_broadcast(
                     identifier=str(broadcast_event.id),
                     message_number=formatted_message_number,
-                    previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
+                    previous_events=get_earlier_events_for_broadcast_event(broadcast_event.id),
                     sent=broadcast_event.sent_at_as_cap_datetime_string,
                 )
 

--- a/app/tasks/broadcast_message_tasks.py
+++ b/app/tasks/broadcast_message_tasks.py
@@ -197,7 +197,7 @@ def send_broadcast_provider_message(*, broadcast_event_id, provider):
         if not is_local_host():
             if broadcast_event.message_type == BroadcastEventMessageType.ALERT:
                 cbc_proxy_provider_client.create_and_send_broadcast(
-                    identifier=str(broadcast_provider_message.id),
+                    identifier=str(broadcast_event.id),
                     message_number=formatted_message_number,
                     headline=HEADLINE,
                     description=broadcast_event.transmitted_content["body"],
@@ -208,7 +208,7 @@ def send_broadcast_provider_message(*, broadcast_event_id, provider):
                 )
             elif broadcast_event.message_type == BroadcastEventMessageType.UPDATE:
                 cbc_proxy_provider_client.update_and_send_broadcast(
-                    identifier=str(broadcast_provider_message.id),
+                    identifier=str(broadcast_event.id),
                     message_number=formatted_message_number,
                     headline=HEADLINE,
                     description=broadcast_event.transmitted_content["body"],
@@ -226,7 +226,7 @@ def send_broadcast_provider_message(*, broadcast_event_id, provider):
                 )
             elif broadcast_event.message_type == BroadcastEventMessageType.CANCEL:
                 cbc_proxy_provider_client.cancel_broadcast(
-                    identifier=str(broadcast_provider_message.id),
+                    identifier=str(broadcast_event.id),
                     message_number=formatted_message_number,
                     previous_provider_messages=broadcast_event.get_earlier_provider_messages(provider),
                     sent=broadcast_event.sent_at_as_cap_datetime_string,

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -105,14 +105,18 @@ def test_get_broadcast_provider_statuses(admin_request, sample_broadcast_service
     )
 
     sending_event = create_broadcast_event(broadcast_message=bm)
+    sending_bpms = dict()
     for mno in mnos:
         # Implicitly creates sending status message_type
         bpm = create_broadcast_provider_message(broadcast_event=sending_event, provider=mno)
+        sending_bpms[mno] = bpm
         add_broadcast_provider_message_status(bpm, status=BROADCAST_PROVIDER_STATUS_ACK)
 
     cancel_event = create_broadcast_event(broadcast_message=bm, message_type="cancel")
+    cancel_bpms = dict()
     for mno in mnos:
         bpm = create_broadcast_provider_message(broadcast_event=cancel_event, provider=mno)
+        cancel_bpms[mno] = bpm
         add_broadcast_provider_message_status(bpm, status=BROADCAST_PROVIDER_STATUS_ERR, error_detail={"test": True})
 
     response = admin_request.get(
@@ -128,9 +132,11 @@ def test_get_broadcast_provider_statuses(admin_request, sample_broadcast_service
         mno_statuses = response[mno]
 
         assert mno_statuses["alertBroadcastEventId"] == str(sending_event.id)
+        assert mno_statuses["alertBroadcastProviderMessageId"] == str(sending_bpms[mno].id)
         assert mno_statuses["alert"][0]["status"] == "sending"
         assert mno_statuses["alert"][1]["status"] == "returned-ack"
         assert mno_statuses["cancelBroadcastEventId"] == str(cancel_event.id)
+        assert mno_statuses["cancelBroadcastProviderMessageId"] == str(cancel_bpms[mno].id)
         assert mno_statuses["cancel"][0]["status"] == "sending"
         assert mno_statuses["cancel"][1]["status"] == "returned-error"
 

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -127,8 +127,10 @@ def test_get_broadcast_provider_statuses(admin_request, sample_broadcast_service
     for mno in mnos:
         mno_statuses = response[mno]
 
+        assert mno_statuses["alertBroadcastEventId"] == str(sending_event.id)
         assert mno_statuses["alert"][0]["status"] == "sending"
         assert mno_statuses["alert"][1]["status"] == "returned-ack"
+        assert mno_statuses["cancelBroadcastEventId"] == str(cancel_event.id)
         assert mno_statuses["cancel"][0]["status"] == "sending"
         assert mno_statuses["cancel"][1]["status"] == "returned-error"
 

--- a/tests/app/clients/test_cbc_proxy.py
+++ b/tests/app/clients/test_cbc_proxy.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 from collections import namedtuple
+from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
 from unittest.mock import Mock, call
@@ -39,7 +40,7 @@ os.environ["AWS_SECRET_ACCESS_KEY"] = "cbc-proxy-aws-secret-access-key"
 
 
 @pytest.fixture(scope="function")
-def cbc_proxy_client(client, mocker):
+def cbc_proxy_client(notify_db_session, client, mocker):
     client = CBCProxyClient()
     current_app = mocker.Mock(
         config={
@@ -179,11 +180,11 @@ def test_cbc_proxy_one_2_many_cancel_invokes_function(mocker, cbc_proxy_client, 
     cbc_proxy = cbc_proxy_client.get_proxy(cbc)
 
     identifier = "my-identifier"
-    MockProviderMessage = namedtuple("BroadcastProviderMessage", ["id", "message_number", "created_at"])
+    MockBroadcastEvent = namedtuple("BroadcastEvent", ["id", "created_at"])
 
-    provider_messages = [
-        MockProviderMessage(uuid.uuid4(), "0000007b", datetime(2020, 12, 16)),
-        MockProviderMessage(uuid.uuid4(), "0000004e", datetime(2020, 12, 17)),
+    previous_events = [
+        MockBroadcastEvent(uuid.uuid4(), datetime(2020, 12, 16)),
+        MockBroadcastEvent(uuid.uuid4(), datetime(2020, 12, 17)),
     ]
     sent = "2020-12-17 14:19:44.130585"
 
@@ -197,9 +198,7 @@ def test_cbc_proxy_one_2_many_cancel_invokes_function(mocker, cbc_proxy_client, 
         "StatusCode": 200,
     }
 
-    cbc_proxy.cancel_broadcast(
-        identifier=identifier, message_number="00000050", previous_provider_messages=provider_messages, sent=sent
-    )
+    cbc_proxy.cancel_broadcast(identifier=identifier, message_number=None, previous_events=previous_events, sent=sent)
 
     ld_client_mock.invoke.assert_called_once_with(
         FunctionName=f"{cbc}-1-proxy",
@@ -216,8 +215,8 @@ def test_cbc_proxy_one_2_many_cancel_invokes_function(mocker, cbc_proxy_client, 
     assert payload["message_format"] == "cap"
     assert payload["message_type"] == "cancel"
     assert payload["references"] == [
-        {"message_id": str(provider_messages[0].id), "sent": provider_messages[0].created_at.strftime(DATETIME_FORMAT)},
-        {"message_id": str(provider_messages[1].id), "sent": provider_messages[1].created_at.strftime(DATETIME_FORMAT)},
+        {"message_id": str(previous_events[0].id), "sent": previous_events[0].created_at.strftime(DATETIME_FORMAT)},
+        {"message_id": str(previous_events[1].id), "sent": previous_events[1].created_at.strftime(DATETIME_FORMAT)},
     ]
     assert payload["sent"] == sent
 
@@ -288,10 +287,21 @@ def test_cbc_proxy_vodafone_create_and_send_invokes_function(
 def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
     identifier = "my-identifier"
     MockProviderMessage = namedtuple("BroadcastProviderMessage", ["id", "message_number", "created_at"])
+    # 123 = 0000007b
+    previous_provider_message = MockProviderMessage(uuid.uuid4(), 123, datetime(2020, 12, 15))
 
-    provider_messages = [
-        MockProviderMessage(uuid.uuid4(), 78, datetime(2020, 12, 16)),
-        MockProviderMessage(uuid.uuid4(), 123, datetime(2020, 12, 17)),
+    @dataclass
+    class MockBroadcastEvent:
+        id: uuid.UUID
+        created_at: datetime
+
+        def get_provider_message(self, provider: str):
+            if provider == "vodafone":
+                return previous_provider_message
+
+    previous_events = [
+        MockBroadcastEvent(uuid.uuid4(), datetime(2020, 12, 16)),
+        MockBroadcastEvent(uuid.uuid4(), datetime(2020, 12, 17)),
     ]
     sent = "2020-12-18 14:19:44.130585"
 
@@ -306,7 +316,7 @@ def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
     }
 
     cbc_proxy_vodafone.cancel_broadcast(
-        identifier=identifier, message_number="00000050", previous_provider_messages=provider_messages, sent=sent
+        identifier=identifier, message_number="00000050", previous_events=previous_events, sent=sent
     )
 
     ld_client_mock.invoke.assert_called_once_with(
@@ -325,14 +335,14 @@ def test_cbc_proxy_vodafone_cancel_invokes_function(mocker, cbc_proxy_vodafone):
     assert payload["message_type"] == "cancel"
     assert payload["references"] == [
         {
-            "message_id": str(provider_messages[0].id),
-            "message_number": "0000004e",
-            "sent": provider_messages[0].created_at.strftime(DATETIME_FORMAT),
+            "message_id": str(previous_events[0].id),
+            "message_number": "0000007b",
+            "sent": previous_events[0].created_at.strftime(DATETIME_FORMAT),
         },
         {
-            "message_id": str(provider_messages[1].id),
-            "message_number": "0000007b",
-            "sent": provider_messages[1].created_at.strftime(DATETIME_FORMAT),
+            "message_id": str(previous_events[1].id),
+            "message_number": "0000007b",  # As a result of mocking, but would be different in practice
+            "sent": previous_events[1].created_at.strftime(DATETIME_FORMAT),
         },
     ]
     assert payload["sent"] == sent

--- a/tests/app/tasks/test_broadcast_message_tasks.py
+++ b/tests/app/tasks/test_broadcast_message_tasks.py
@@ -162,7 +162,7 @@ def test_send_broadcast_provider_message_sends_data_correctly(
     assert broadcast_provider_message.get_latest_status_entry().status == BROADCAST_PROVIDER_STATUS_ACK
 
     mock_create_broadcast.assert_called_once_with(
-        identifier=str(broadcast_provider_message.id),
+        identifier=str(event.id),
         message_number=mocker.ANY,
         headline="GOV.UK Emergency Alert",
         description="this is an emergency broadcast message",
@@ -275,7 +275,7 @@ def test_send_broadcast_provider_message_works_if_we_retried_previously(mocker, 
     assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
     mock_create_broadcast.assert_called_once_with(
-        identifier=str(broadcast_provider_message.id),
+        identifier=str(event.id),
         message_number=mocker.ANY,
         headline="GOV.UK Emergency Alert",
         description="this is an emergency broadcast message",
@@ -320,10 +320,8 @@ def test_send_broadcast_provider_message_sends_data_correctly_when_broadcast_mes
 
     send_broadcast_provider_message(provider=provider, broadcast_event_id=str(event.id))
 
-    broadcast_provider_message = event.get_provider_message(provider)
-
     mock_create_broadcast.assert_called_once_with(
-        identifier=str(broadcast_provider_message.id),
+        identifier=str(event.id),
         message_number=mocker.ANY,
         headline="GOV.UK Emergency Alert",
         description="this is an emergency broadcast message",
@@ -378,7 +376,7 @@ def test_send_broadcast_provider_message_sends_update_with_references(
     assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
     mock_update_broadcast.assert_called_once_with(
-        identifier=str(broadcast_provider_message.id),
+        identifier=str(update_event.id),
         message_number=mocker.ANY,
         headline="GOV.UK Emergency Alert",
         description="this is an emergency broadcast message",
@@ -439,7 +437,7 @@ def test_send_broadcast_provider_message_sends_cancel_with_references(
     assert broadcast_provider_message.get_latest_status_entry() == broadcast_provider_message.statuses[1]
 
     mock_cancel_broadcast.assert_called_once_with(
-        identifier=str(broadcast_provider_message.id),
+        identifier=str(cancel_event.id),
         message_number=mocker.ANY,
         previous_provider_messages=[
             alert_event.get_provider_message(provider),

--- a/tests/app/tasks/test_broadcast_message_tasks.py
+++ b/tests/app/tasks/test_broadcast_message_tasks.py
@@ -385,7 +385,7 @@ def test_send_broadcast_provider_message_sends_update_with_references(
                 "polygon": [[50.12, 1.2], [50.13, 1.2], [50.14, 1.21]],
             }
         ],
-        previous_provider_messages=[alert_event.get_provider_message(provider)],
+        previous_events=[alert_event],
         sent=update_event.sent_at_as_cap_datetime_string,
         expires=update_event.transmitted_finishes_at_as_cap_datetime_string,
         channel="severe",
@@ -439,9 +439,9 @@ def test_send_broadcast_provider_message_sends_cancel_with_references(
     mock_cancel_broadcast.assert_called_once_with(
         identifier=str(cancel_event.id),
         message_number=mocker.ANY,
-        previous_provider_messages=[
-            alert_event.get_provider_message(provider),
-            update_event.get_provider_message(provider),
+        previous_events=[
+            alert_event,
+            update_event,
         ],
         sent=cancel_event.sent_at_as_cap_datetime_string,
     )


### PR DESCRIPTION
> Draft because there's other PRs to roll out first to rejig testing, one of which is included here.

This should unify the ID we give for an alerts to all MNOs, instead of each one being unique.

By and large this is a simple change on the sending side, but explicit cancelling requires referring to the prior alert ID. This has been replicated too, but for IBAG-based networks specifically we need to delve into the BroadcastProviderMessage again to get the message sequence number.

This would warrant some testing against real CBCs, namely around the cancelling behaviour. I'm running functional tests with CBC support in my hosted dev.

The CBC code seems to be oriented around accepting multiple previous messages but I don't foresee when that would ever happen. Perhaps if UPDATEs were implemented, a cancel would refer to the initial alert and subsequent updates perhaps?