### PR TITLE
EAS-3213 Prevent test fixtures purging all alerts

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -494,7 +494,6 @@ def purge_broadcast_messages(service_id=None, older_than=365):
                         counter["s3_deletion_errors"] += len(s3_result.get("Errors", []))
 
                 # delete database records associated with this message
-                # counter += dao_delete_records_for_broadcast(service_id, message[0])
                 counter += dao_delete_records_for_broadcast(message[0])
 
             current_app.logger.info(

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -423,25 +423,29 @@ def return_broadcast_message_for_edit(service_id, broadcast_message_id):
 
 
 @broadcast_message_blueprint.route("/purge/<int:older_than>", methods=["DELETE"])
-def purge_broadcast_messages(service_id, older_than):
+def purge_service_broadcast_messages(service_id, older_than):
     if is_public_environment():
         raise InvalidRequest("Endpoint not found", status_code=404)
+    return purge_broadcast_messages(service_id=service_id, older_than=older_than)
 
+
+def purge_broadcast_messages(service_id=None, older_than=365):
     result_message = (
-        "Purged {0} BroadcastMessage items, {1} BroadcastEvent items and {2} S3 objects, created more than {3} days ago"
+        "Purged {0} ({1}) BroadcastMessage items, {2} BroadcastEvent items "
+        "and {3} S3 objects, created more than {4} days ago"
     )
 
     try:
         bucket = current_app.config["GOVUK_ALERTS_S3_BUCKET_NAME"]
         s3 = boto3.client("s3")
         counter = Counter()
-        messages = _generate_s3_keys(dao_get_public_messages_older_than(older_than))
+        messages = _generate_s3_keys(dao_get_public_messages_older_than(service_id, older_than))
 
         current_app.logger.info(
             "purge_broadcast_messages",
             extra={
                 "python_module": __name__,
-                "service_id": service_id,
+                "service_id": service_id if service_id else "all services",
                 "bucket": bucket,
                 "older_than": older_than,
                 "messages": messages,
@@ -490,24 +494,37 @@ def purge_broadcast_messages(service_id, older_than):
                         counter["s3_deletion_errors"] += len(s3_result.get("Errors", []))
 
                 # delete database records associated with this message
-                counter += dao_delete_records_for_broadcast(service_id, message[0])
+                # counter += dao_delete_records_for_broadcast(service_id, message[0])
+                counter += dao_delete_records_for_broadcast(message[0])
 
             current_app.logger.info(
-                result_message.format(counter["msgs"], counter["events"], counter["s3_objects"], older_than)
+                result_message.format(
+                    counter["msgs"],
+                    service_id if service_id else "all services",
+                    counter["events"],
+                    counter["s3_objects"],
+                    older_than,
+                )
             )
 
     except Exception as e:
         return jsonify(result="error", message=f"Unable to purge old alert items: {e}"), 500
 
-    # Also remove things exclusively from the DB (rejected, draft, etc)
-    db_purge = dao_purge_old_broadcast_messages(service_id, older_than)
-    current_app.logger.info("Additional removed DB items: %s", db_purge)
+    # Also remove alerts not broadcast (rejected, draft, etc)
+    non_public_messages_purged = dao_purge_old_broadcast_messages(service_id, older_than)
+    current_app.logger.info("Additional purged items: %s", non_public_messages_purged)
 
     return (
         jsonify(
             {
-                "message": result_message.format(counter["msgs"], counter["events"], counter["s3_objects"], older_than),
-                "additional_db_purge": db_purge,
+                "message": result_message.format(
+                    counter["msgs"],
+                    service_id if service_id else "all services",
+                    counter["events"],
+                    counter["s3_objects"],
+                    older_than,
+                ),
+                "additional_messages_purged": non_public_messages_purged,
             }
         ),
         200,

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -371,14 +371,6 @@ def dao_purge_old_broadcast_messages(service, days_older_than=30, dry_run=False)
     return counter
 
 
-# def dao_delete_records_for_broadcast(service, message_id, dry_run=False):
-# if service is None:
-#     raise ValueError("Service ID is required")
-
-
-# service_id = _resolve_service_id(service)
-# if service_id is None:
-#     raise ValueError("Unable to find service ID")
 def dao_delete_records_for_broadcast(message_id, dry_run=False):
     counter = Counter()
     try:

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -292,8 +292,8 @@ def dao_get_all_finished_broadcast_messages_with_outstanding_actions() -> list[B
     )
 
 
-def dao_get_public_messages_older_than(days):
-    messages = (
+def dao_get_public_messages_older_than(service_id, days):
+    query = (
         db.session.query(
             BroadcastMessage.id,
             BroadcastMessage.starts_at,
@@ -305,9 +305,12 @@ def dao_get_public_messages_older_than(days):
             BroadcastMessage.status.in_(BroadcastStatusType.LIVE_STATUSES),
             ServiceBroadcastSettings.channel.in_(ServiceBroadcastSettings.PUBLIC_CHANNEL),
         )
-        .order_by(asc(BroadcastMessage.starts_at))
-        .all()
     )
+
+    if service_id is not None:
+        query = query.filter(BroadcastMessage.service_id == service_id)
+
+    messages = query.order_by(asc(BroadcastMessage.starts_at)).all()
     return [(str(row[0]), row[1]) for row in messages]
 
 
@@ -368,14 +371,15 @@ def dao_purge_old_broadcast_messages(service, days_older_than=30, dry_run=False)
     return counter
 
 
-def dao_delete_records_for_broadcast(service, message_id, dry_run=False):
-    if service is None:
-        raise ValueError("Service ID is required")
+# def dao_delete_records_for_broadcast(service, message_id, dry_run=False):
+# if service is None:
+#     raise ValueError("Service ID is required")
 
-    service_id = _resolve_service_id(service)
-    if service_id is None:
-        raise ValueError("Unable to find service ID")
 
+# service_id = _resolve_service_id(service)
+# if service_id is None:
+#     raise ValueError("Unable to find service ID")
+def dao_delete_records_for_broadcast(message_id, dry_run=False):
     counter = Counter()
     try:
         broadcast_event_ids = _get_broadcast_event_ids(message_id)

--- a/app/tasks/scheduled_tasks.py
+++ b/app/tasks/scheduled_tasks.py
@@ -7,6 +7,7 @@ from periodiq import cron
 from sqlalchemy.exc import SQLAlchemyError
 
 from app import db, dramatiq
+from app.broadcast_message.rest import purge_broadcast_messages
 from app.dao.broadcast_message_dao import (
     dao_get_all_finished_broadcast_messages_with_outstanding_actions,
 )
@@ -205,3 +206,26 @@ def queue_after_alert_activities():
             current_app.logger.info("Enqueued publish GOV UK Alerts: %s", publish_task.asdict())
 
         # Down the line we will look to request logs from MNOs
+
+
+@dramatiq.actor(
+    actor_name=TaskNames.PURGE_OLD_ALERTS_FROM_PREVIEW_ENVIRONMENT,
+    queue_name=QueueNames.PERIODIC,
+    periodic=cron("15 10 * * 2"),  # Every Tuesday at 10:15 UTC
+)
+def purge_old_alerts_from_preview_environment():
+    """
+    Purge old alerts from the preview environment.
+    Preview already purges the alerts created by the functional test
+    service; this task purges any other alerts that may have been
+    created manually or through the API.
+    As the non-test alerts may be supporting long-termmanual testing
+    activities, we only purge alerts older that 1 year.
+    """
+    if current_app.config["ENVIRONMENT"] == "preview":
+        try:
+            purge_broadcast_messages(service_id=None, older_than=365)
+            current_app.logger.info("Purged messages older than 1 year from preview environment")
+        except Exception as e:
+            current_app.logger.exception(f"Unable to purge preview messages: {e}")
+            raise

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -899,9 +899,9 @@ def test_return_broadcast_message_for_edit_errors_with_empty_reason(admin_reques
     assert response["message"] == "Enter the reason for returning the alert for edit"
 
 
-def test_purge_broadcast_messages(admin_request, sample_broadcast_service, mocker):
+def test_purge_service_broadcast_messages(admin_request, sample_broadcast_service, mocker):
     response = admin_request.delete(
-        "broadcast_message.purge_broadcast_messages",
+        "broadcast_message.purge_service_broadcast_messages",
         service_id=sample_broadcast_service.id,
         older_than=100,
         _expected_status=200,
@@ -910,7 +910,7 @@ def test_purge_broadcast_messages(admin_request, sample_broadcast_service, mocke
     print(response["message"])
 
     pattern = (
-        r"Purged (\d+) BroadcastMessage items, (\d+) BroadcastEvent items"
+        r"Purged (\d+) \(.*\) BroadcastMessage items, (\d+) BroadcastEvent items"
         r" and (\d+) S3 objects, created more than 100 days ago"
     )
     assert re.match(pattern, response["message"])

--- a/tests/app/dao/test_broadcast_message_dao.py
+++ b/tests/app/dao/test_broadcast_message_dao.py
@@ -756,14 +756,12 @@ def test_dao_delete_records_for_broadcast(sample_broadcast_service, sample_broad
     _ = create_broadcast_provider_message(be2, "three")
     _ = create_broadcast_provider_message(be2, "vodafone")
 
-    # counter = dao_delete_records_for_broadcast(template_severe.service_id, bm1.id)
     counter = dao_delete_records_for_broadcast(bm1.id)
 
     assert counter["msgs"] == 1
     assert counter["events"] == 1
     assert counter["provider_msgs"] == 2
 
-    # counter = dao_delete_records_for_broadcast(template_government.service_id, bm2.id)
     counter = dao_delete_records_for_broadcast(bm2.id)
 
     assert counter["msgs"] == 1

--- a/tests/app/dao/test_broadcast_message_dao.py
+++ b/tests/app/dao/test_broadcast_message_dao.py
@@ -727,7 +727,7 @@ def test_dao_get_public_messages_older_than(
         template_severe, starts_at=datetime(2025, 6, 19, 12, 0, 0), status="completed"
     )  # excluded: not old enough
 
-    broadcast_messages = dao_get_public_messages_older_than(3)
+    broadcast_messages = dao_get_public_messages_older_than(None, 3)
     assert len(broadcast_messages) == 3
 
 
@@ -756,13 +756,15 @@ def test_dao_delete_records_for_broadcast(sample_broadcast_service, sample_broad
     _ = create_broadcast_provider_message(be2, "three")
     _ = create_broadcast_provider_message(be2, "vodafone")
 
-    counter = dao_delete_records_for_broadcast(template_severe.service_id, bm1.id)
+    # counter = dao_delete_records_for_broadcast(template_severe.service_id, bm1.id)
+    counter = dao_delete_records_for_broadcast(bm1.id)
 
     assert counter["msgs"] == 1
     assert counter["events"] == 1
     assert counter["provider_msgs"] == 2
 
-    counter = dao_delete_records_for_broadcast(template_government.service_id, bm2.id)
+    # counter = dao_delete_records_for_broadcast(template_government.service_id, bm2.id)
+    counter = dao_delete_records_for_broadcast(bm2.id)
 
     assert counter["msgs"] == 1
     assert counter["events"] == 1


### PR DESCRIPTION
The functional test fixture will now only purge alerts created by the functional test account. A scheduled task has been added to purge all alerts over 1 year old from the preview environment.