### PR TITLE
EAS-3229: Add broadcast event/provider IDs to provider-statuses

### DIFF
--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -138,7 +138,10 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
     messages = dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id)
 
     # Create a structure like:
-    # { "<mno>": { "alertBroadcastEventId": "", "alert": [{}], "cancelBroadcastEventId": "", "cancel": [{}] } }
+    # { "<mno>": {
+    #   "alertBroadcastEventId": "", "alertBroadcastProviderMessageId": "", "alert": [{}],
+    #   "cancelBroadcastEventId": "", "cancelBroadcastProviderMessageId", "", "cancel": [{}]
+    # } }
     # (yes, the broadcast event ID will be the same for each MNO - it's to keep the data structure backwards compatible)
 
     result = {}
@@ -147,8 +150,10 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
             broadcast_provider_message.provider,
             {
                 "alertBroadcastEventId": None,
+                "alertBroadcastProviderMessageId": None,
                 BroadcastEventMessageType.ALERT: [],
                 "cancelBroadcastEventId": None,
+                "cancelBroadcastProviderMessageId": None,
                 BroadcastEventMessageType.CANCEL: [],
             },
         )
@@ -167,10 +172,18 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
             result[broadcast_provider_message.provider][
                 "alertBroadcastEventId"
             ] = broadcast_provider_message.broadcast_event_id
+
+            result[broadcast_provider_message.provider][
+                "alertBroadcastProviderMessageId"
+            ] = broadcast_provider_message.id
         elif broadcast_event_message_type == "cancel":
             result[broadcast_provider_message.provider][
                 "cancelBroadcastEventId"
             ] = broadcast_provider_message.broadcast_event_id
+
+            result[broadcast_provider_message.provider][
+                "cancelBroadcastProviderMessageId"
+            ] = broadcast_provider_message.id
 
         result[broadcast_provider_message.provider][broadcast_event_message_type] = statuses
 

--- a/app/broadcast_message/rest.py
+++ b/app/broadcast_message/rest.py
@@ -138,13 +138,19 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
     messages = dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id)
 
     # Create a structure like:
-    # { "<mno>": { "alert": [{}], "cancel": [{}] } }
+    # { "<mno>": { "alertBroadcastEventId": "", "alert": [{}], "cancelBroadcastEventId": "", "cancel": [{}] } }
+    # (yes, the broadcast event ID will be the same for each MNO - it's to keep the data structure backwards compatible)
 
     result = {}
     for broadcast_provider_message, broadcast_event_message_type in messages:
         result.setdefault(
             broadcast_provider_message.provider,
-            {BroadcastEventMessageType.ALERT: [], BroadcastEventMessageType.CANCEL: []},
+            {
+                "alertBroadcastEventId": None,
+                BroadcastEventMessageType.ALERT: [],
+                "cancelBroadcastEventId": None,
+                BroadcastEventMessageType.CANCEL: [],
+            },
         )
 
         # This relationship has an order_by and thus should be in old to new order
@@ -157,11 +163,21 @@ def get_broadcast_provider_statuses(service_id, broadcast_message_id):
             for status_db in broadcast_provider_message.statuses
         ]
 
+        if broadcast_event_message_type == "alert":
+            result[broadcast_provider_message.provider][
+                "alertBroadcastEventId"
+            ] = broadcast_provider_message.broadcast_event_id
+        elif broadcast_event_message_type == "cancel":
+            result[broadcast_provider_message.provider][
+                "cancelBroadcastEventId"
+            ] = broadcast_provider_message.broadcast_event_id
+
         result[broadcast_provider_message.provider][broadcast_event_message_type] = statuses
 
     return jsonify(result)
 
 
+# Deprecated: Only used by functional tests prior to migration to provider-statuses
 @broadcast_message_blueprint.route("/<uuid:broadcast_message_id>/provider-messages", methods=["GET"])
 def get_broadcast_provider_messages(service_id, broadcast_message_id):
     messages = dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id)

--- a/app/dao/broadcast_message_dao.py
+++ b/app/dao/broadcast_message_dao.py
@@ -161,7 +161,9 @@ def dao_get_broadcast_provider_messages_by_broadcast_message_ids(
     )
 
 
-def dao_get_broadcast_provider_messages_by_broadcast_message_id(broadcast_message_id):
+def dao_get_broadcast_provider_messages_by_broadcast_message_id(
+    broadcast_message_id,
+) -> list[tuple[BroadcastProviderMessage, str]]:
     return (
         db.session.query(
             BroadcastProviderMessage,

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -105,14 +105,18 @@ def test_get_broadcast_provider_statuses(admin_request, sample_broadcast_service
     )
 
     sending_event = create_broadcast_event(broadcast_message=bm)
+    sending_bpms = dict()
     for mno in mnos:
         # Implicitly creates sending status message_type
         bpm = create_broadcast_provider_message(broadcast_event=sending_event, provider=mno)
+        sending_bpms[mno] = bpm
         add_broadcast_provider_message_status(bpm, status=BROADCAST_PROVIDER_STATUS_ACK)
 
     cancel_event = create_broadcast_event(broadcast_message=bm, message_type="cancel")
+    cancel_bpms = dict()
     for mno in mnos:
         bpm = create_broadcast_provider_message(broadcast_event=cancel_event, provider=mno)
+        cancel_bpms[mno] = bpm
         add_broadcast_provider_message_status(bpm, status=BROADCAST_PROVIDER_STATUS_ERR, error_detail={"test": True})
 
     response = admin_request.get(
@@ -128,9 +132,11 @@ def test_get_broadcast_provider_statuses(admin_request, sample_broadcast_service
         mno_statuses = response[mno]
 
         assert mno_statuses["alertBroadcastEventId"] == str(sending_event.id)
+        assert mno_statuses["alertBroadcastProviderMessageId"] == str(sending_bpms[mno].id)
         assert mno_statuses["alert"][0]["status"] == "sending"
         assert mno_statuses["alert"][1]["status"] == "returned-ack"
         assert mno_statuses["cancelBroadcastEventId"] == str(cancel_event.id)
+        assert mno_statuses["cancelBroadcastProviderMessageId"] == str(cancel_bpms[mno].id)
         assert mno_statuses["cancel"][0]["status"] == "sending"
         assert mno_statuses["cancel"][1]["status"] == "returned-error"
 

--- a/tests/app/broadcast_message/test_rest.py
+++ b/tests/app/broadcast_message/test_rest.py
@@ -127,8 +127,10 @@ def test_get_broadcast_provider_statuses(admin_request, sample_broadcast_service
     for mno in mnos:
         mno_statuses = response[mno]
 
+        assert mno_statuses["alertBroadcastEventId"] == str(sending_event.id)
         assert mno_statuses["alert"][0]["status"] == "sending"
         assert mno_statuses["alert"][1]["status"] == "returned-ack"
+        assert mno_statuses["cancelBroadcastEventId"] == str(cancel_event.id)
         assert mno_statuses["cancel"][0]["status"] == "sending"
         assert mno_statuses["cancel"][1]["status"] == "returned-error"
 


### PR DESCRIPTION
This is a very simple one, but means with upcoming functional test refactoring we can get the 'full' status history now we store it, and better assert what's going on.